### PR TITLE
initial dealbot daemon

### DIFF
--- a/commands/context.go
+++ b/commands/context.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var (
+	processContext     context.Context
+	processContextOnce sync.Once
+)
+
+func ProcessContext() context.Context {
+	processContextOnce.Do(func() {
+		var cancel context.CancelFunc
+		processContext, cancel = context.WithCancel(context.Background())
+
+		notify := make(chan os.Signal, 2)
+		signal.Notify(notify, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			defer signal.Stop(notify)
+
+			<-notify
+			cancel()
+
+			select {
+			case <-time.After(30 * time.Second):
+				fmt.Println("Timed out on shutdown, terminating...")
+			case <-notify:
+				fmt.Println("Received another interrupt before graceful shutdown, terminating...")
+			}
+			os.Exit(-1)
+		}()
+	})
+	return processContext
+}

--- a/commands/coordinate.go
+++ b/commands/coordinate.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/filecoin-project/dealbot/config"
+	"github.com/filecoin-project/dealbot/tasks"
+	"github.com/urfave/cli/v2"
+)
+
+var CoordinateCmd = &cli.Command{
+	Name:   "coordinate",
+	Usage:  "run multiple deals configured by a json input on stdin",
+	Action: coordinateCommand,
+	Flags:  DealFlags,
+}
+
+func coordinateCommand(cctx *cli.Context) error {
+	cfg := &config.EnvConfig{}
+	if err := cfg.Load(); err != nil {
+		return err
+	}
+
+	taskList, err := parseTasks()
+	if err != nil {
+		return err
+	}
+
+	clientConfig, node, closer, err := setupCLIClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	logger := func(msg string, keysAndValues ...interface{}) {
+		log.Infow(msg, keysAndValues...)
+	}
+
+	for _, task := range taskList {
+		var err error
+		switch t := task.(type) {
+		case tasks.StorageDealTask:
+			err = tasks.MakeStorageDeal(cctx.Context, clientConfig, node, t, logger)
+		case tasks.RetrievalTask:
+			err = tasks.MakeRetrievalDeal(cctx.Context, clientConfig, node, t, logger)
+		}
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
+	return nil
+}
+
+func parseTasks() ([]interface{}, error) {
+	stdin := bufio.NewReader(os.Stdin)
+	dec := json.NewDecoder(stdin)
+
+	var tasksJson []map[string]interface{}
+	err := dec.Decode(&tasksJson)
+	if err != nil {
+		return nil, err
+	}
+
+	taskList := make([]interface{}, len(tasksJson))
+	for i, taskJson := range tasksJson {
+		switch taskJson["Task"] {
+		case "retrieval":
+			var task tasks.RetrievalTask
+			err := (&task).FromMap(taskJson)
+			if err != nil {
+				return nil, err
+			}
+			taskList[i] = task
+		case "storage":
+			var task tasks.StorageDealTask
+			err := (&task).FromMap(taskJson)
+			if err != nil {
+				return nil, err
+			}
+			taskList[i] = task
+		default:
+			return nil, fmt.Errorf("unknown task type: %v", taskJson["Task"])
+		}
+	}
+	return taskList, nil
+}

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/dealbot/config"
+	"github.com/filecoin-project/dealbot/daemon"
+	"github.com/urfave/cli/v2"
+)
+
+var DaemonCmd = &cli.Command{
+	Name:   "daemon",
+	Usage:  "Start a dealbot daemon, accepting tasks over RPC",
+	Action: daemonCommand,
+}
+
+func daemonCommand(c *cli.Context) error {
+	ctx, cancel := context.WithCancel(ProcessContext())
+	defer cancel()
+
+	cfg := &config.EnvConfig{}
+	if err := cfg.Load(); err != nil {
+		return err
+	}
+
+	srv, err := daemon.New(cfg)
+	if err != nil {
+		return err
+	}
+
+	exiting := make(chan struct{})
+	defer close(exiting)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-exiting:
+			// no need to shutdown in this case.
+			return
+		}
+
+		log.Infow("shutting down rpc server")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Fatalw("failed to shut down rpc server", "err", err)
+		}
+		log.Infow("rpc server stopped")
+	}()
+
+	log.Infow("listen and serve", "addr", srv.Addr())
+	err = srv.Serve()
+	if err == http.ErrServerClosed {
+		err = nil
+	}
+	return err
+}

--- a/commands/retrieval_deal.go
+++ b/commands/retrieval_deal.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var MakeRetrievalDeal = &cli.Command{
+var MakeRetrievalDealCmd = &cli.Command{
 	Name:  "retrieval-deal",
 	Usage: "Make retrieval deals with provided miners.",
 	Flags: []cli.Flag{

--- a/commands/retrieval_deal.go
+++ b/commands/retrieval_deal.go
@@ -2,63 +2,29 @@ package commands
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/lotus/api"
-	"github.com/ipfs/go-cid"
+	"github.com/filecoin-project/dealbot/tasks"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/xerrors"
 )
 
 var MakeRetrievalDealCmd = &cli.Command{
 	Name:  "retrieval-deal",
 	Usage: "Make retrieval deals with provided miners.",
-	Flags: []cli.Flag{
+	Flags: append(SingleTaskFlags, []cli.Flag{
 		&cli.StringFlag{
 			Name:  "cid",
 			Usage: "payload cid to fetch from miner",
 			Value: "bafykbzacedikkmeotawrxqquthryw3cijaonobygdp7fb5bujhuos6wdkwomm",
 		},
-	},
+	}...),
 	Action: makeRetrievalDeal,
 }
 
 func makeRetrievalDeal(cctx *cli.Context) error {
-	if err := setupLogging(cctx); err != nil {
-		return xerrors.Errorf("setup logging: %w", err)
-	}
-
-	// start API to lotus node
-	opener, closer, err := setupLotusAPI(cctx)
+	clientConfig, node, closer, err := setupCLIClient(cctx)
 	if err != nil {
 		return err
 	}
 	defer closer()
-
-	_ = opener
-
-	node, jsoncloser, err := opener.Open(cctx.Context)
-	if err != nil {
-		return err
-	}
-	defer jsoncloser()
-
-	// read addresses and assert they are addresses
-	var walletAddress address.Address
-	if cctx.IsSet("wallet") {
-		log.Infow("using set wallet", cctx.String("wallet"))
-		walletAddress, err = address.NewFromString(cctx.String("wallet"))
-	} else {
-		log.Infow("using default wallet")
-		walletAddress, err = node.WalletDefaultAddress(context.Background())
-	}
-	if err != nil {
-		return fmt.Errorf("wallet is not a Filecoin address: %s, %s", cctx.String("wallet"), err)
-	}
 
 	v, err := node.Version(context.Background())
 	if err != nil {
@@ -68,68 +34,27 @@ func makeRetrievalDeal(cctx *cli.Context) error {
 	log.Infof("remote version: %s", v.Version)
 
 	carExport := true
-	payloadCid, err := cid.Parse(cctx.String("cid"))
-	if err != nil {
-		panic(err)
-	}
+	payloadCid := cctx.String("cid")
 
 	log.Infof("retrieving cid: %s", payloadCid)
 
 	// get miner address
 	minerParam := cctx.String("miner")
-	minerAddress, err := address.NewFromString(minerParam)
-	if err != nil {
-		return fmt.Errorf("miner is not a Filecoint address: %s, %s", minerParam, err)
+
+	task := tasks.RetrievalTask{
+		Miner:      minerParam,
+		PayloadCID: payloadCid,
+		CarExport:  carExport,
 	}
 
-	err = RetrieveData(context.Background(), node, minerAddress, walletAddress, payloadCid, carExport)
+	err = tasks.MakeRetrievalDeal(cctx.Context, clientConfig, node, task, func(msg string, keysAndValues ...interface{}) {
+		log.Infow(msg, keysAndValues...)
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	log.Info("successfully retrieved")
-
-	return nil
-}
-
-func RetrieveData(ctx context.Context, client api.FullNode, miner address.Address, caddr address.Address, fcid cid.Cid, carExport bool) error {
-	offer, err := client.ClientMinerQueryOffer(ctx, miner, fcid, nil)
-	if err != nil {
-		return err
-	}
-
-	if offer.Err != "" {
-		return fmt.Errorf("got error in offer: %s", offer.Err)
-	}
-
-	log.Infow("got query offer", "root", offer.Root, "piece", offer.Piece, "size", offer.Size, "minprice", offer.MinPrice, "unseal_price", offer.UnsealPrice)
-
-	rpath, err := ioutil.TempDir("", "dealbot-retrieve-test-")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(rpath)
-
-	ref := &api.FileRef{
-		Path:  filepath.Join(rpath, "ret"),
-		IsCAR: carExport,
-	}
-
-	err = client.ClientRetrieve(ctx, offer.Order(caddr), ref)
-	if err != nil {
-		return err
-	}
-
-	rdata, err := ioutil.ReadFile(filepath.Join(rpath, "ret"))
-	if err != nil {
-		return err
-	}
-
-	_ = rdata
-
-	//if carExport {
-	//rdata = ExtractCarData(ctx, rdata, rpath)
-	//}
 
 	return nil
 }

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -51,11 +51,11 @@ func setupLotusAPI(cctx *cli.Context) (*lotus.APIOpener, lotus.APICloser, error)
 
 var CommonFlags []cli.Flag = []cli.Flag{
 	&cli.PathFlag{
-		Name:     "data-dir",
-		Usage:    "writable directory used to transfer data to node",
-		Aliases:  []string{"d"},
-		EnvVars:  []string{"DEALBOT_DATA_DIRECTORY"},
-		Required: true,
+		Name:    "data-dir",
+		Usage:   "writable directory used to transfer data to node",
+		Aliases: []string{"d"},
+		EnvVars: []string{"DEALBOT_DATA_DIRECTORY"},
+		//Required: true,
 	},
 	&cli.PathFlag{
 		Name:    "node-data-dir",
@@ -70,11 +70,11 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		EnvVars: []string{"DEALBOT_WALLET_ADDRESS"},
 	},
 	&cli.StringFlag{
-		Name:     "miner",
-		Usage:    "address of miner to make deal with",
-		Aliases:  []string{"m"},
-		EnvVars:  []string{"DEALBOT_MINER_ADDRESS"},
-		Required: true,
+		Name:    "miner",
+		Usage:   "address of miner to make deal with",
+		Aliases: []string{"m"},
+		EnvVars: []string{"DEALBOT_MINER_ADDRESS"},
+		//Required: true,
 	},
 	&cli.Int64Flag{
 		Name:    "start-offset",

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -1,6 +1,11 @@
 package commands
 
 import (
+	"fmt"
+	"github.com/filecoin-project/dealbot/tasks"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"os"
 	"strings"
 
 	"github.com/filecoin-project/dealbot/lotus"
@@ -13,6 +18,8 @@ import (
 )
 
 var log = logging.Logger("dealbot")
+
+type NodeCloser func()
 
 func setupLogging(cctx *cli.Context) error {
 	ll := cctx.String("log-level")
@@ -50,12 +57,21 @@ func setupLotusAPI(cctx *cli.Context) (*lotus.APIOpener, lotus.APICloser, error)
 }
 
 var CommonFlags []cli.Flag = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "wallet",
+		Usage:   "deal client wallet address on node",
+		Aliases: []string{"w"},
+		EnvVars: []string{"DEALBOT_WALLET_ADDRESS"},
+	},
+}
+
+var DealFlags = []cli.Flag{
 	&cli.PathFlag{
-		Name:    "data-dir",
-		Usage:   "writable directory used to transfer data to node",
-		Aliases: []string{"d"},
-		EnvVars: []string{"DEALBOT_DATA_DIRECTORY"},
-		//Required: true,
+		Name:     "data-dir",
+		Usage:    "writable directory used to transfer data to node",
+		Aliases:  []string{"d"},
+		EnvVars:  []string{"DEALBOT_DATA_DIRECTORY"},
+		Required: true,
 	},
 	&cli.PathFlag{
 		Name:    "node-data-dir",
@@ -63,23 +79,67 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		Aliases: []string{"n"},
 		EnvVars: []string{"DEALBOT_NODE_DATA_DIRECTORY"},
 	},
+}
+
+var SingleTaskFlags = append(DealFlags, []cli.Flag{
 	&cli.StringFlag{
-		Name:    "wallet",
-		Usage:   "deal client wallet address on node",
-		Aliases: []string{"w"},
-		EnvVars: []string{"DEALBOT_WALLET_ADDRESS"},
+		Name:     "miner",
+		Usage:    "address of miner to make deal with",
+		Aliases:  []string{"m"},
+		EnvVars:  []string{"DEALBOT_MINER_ADDRESS"},
+		Required: true,
 	},
-	&cli.StringFlag{
-		Name:    "miner",
-		Usage:   "address of miner to make deal with",
-		Aliases: []string{"m"},
-		EnvVars: []string{"DEALBOT_MINER_ADDRESS"},
-		//Required: true,
-	},
-	&cli.Int64Flag{
-		Name:    "start-offset",
-		Usage:   "epochs deal start will be offset from now [5760 (2 days)]",
-		EnvVars: []string{"DEALBOT_START_OFFSET"},
-		Value:   30760,
-	},
+}...)
+
+func setupCLIClient(cctx *cli.Context) (tasks.ClientConfig, api.FullNode, NodeCloser, error) {
+	// read dir and assert it exists
+	dataDir := cctx.String("data-dir")
+	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
+		return tasks.ClientConfig{}, nil, nil, fmt.Errorf("data-dir does not exist: %s", dataDir)
+	}
+
+	nodeDataDir := cctx.String("node-data-dir")
+	if nodeDataDir == "" {
+		nodeDataDir = dataDir
+	}
+
+	if err := setupLogging(cctx); err != nil {
+		return tasks.ClientConfig{}, nil, nil, xerrors.Errorf("setup logging: %w", err)
+	}
+
+	// start API to lotus node
+	opener, apiCloser, err := setupLotusAPI(cctx)
+	if err != nil {
+		return tasks.ClientConfig{}, nil, nil, err
+	}
+
+	node, jsoncloser, err := opener.Open(cctx.Context)
+	if err != nil {
+		apiCloser()
+		return tasks.ClientConfig{}, nil, nil, err
+	}
+
+	closer := func() {
+		apiCloser()
+		jsoncloser()
+	}
+
+	// read addresses and assert they are addresses
+	var walletAddress address.Address
+	if cctx.IsSet("wallet") {
+		log.Infow("using set wallet", cctx.String("wallet"))
+		walletAddress, err = address.NewFromString(cctx.String("wallet"))
+	} else {
+		log.Infow("using default wallet")
+		walletAddress, err = node.WalletDefaultAddress(cctx.Context)
+	}
+	if err != nil {
+		return tasks.ClientConfig{}, nil, nil, fmt.Errorf("wallet is not a Filecoin address: %s, %s", cctx.String("wallet"), err)
+	}
+
+	return tasks.ClientConfig{
+		DataDir:       dataDir,
+		NodeDataDir:   nodeDataDir,
+		WalletAddress: walletAddress,
+	}, node, closer, nil
 }

--- a/commands/storage_deal.go
+++ b/commands/storage_deal.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var MakeStorageDeal = &cli.Command{
+var MakeStorageDealCmd = &cli.Command{
 	Name:  "storage-deal",
 	Usage: "Make storage deals with provided miners.",
 	Flags: []cli.Flag{

--- a/commands/storage_deal.go
+++ b/commands/storage_deal.go
@@ -1,29 +1,16 @@
 package commands
 
 import (
-	"context"
-	"crypto/rand"
 	"fmt"
-	"io"
-	"os"
-	"path"
-
 	"github.com/c2h5oh/datasize"
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-fil-markets/storagemarket"
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/google/uuid"
+	"github.com/filecoin-project/dealbot/tasks"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/xerrors"
 )
 
 var MakeStorageDealCmd = &cli.Command{
 	Name:  "storage-deal",
 	Usage: "Make storage deals with provided miners.",
-	Flags: []cli.Flag{
+	Flags: append(SingleTaskFlags, []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "fast-retrieval",
 			Usage:   "request fast retrieval [true]",
@@ -51,59 +38,22 @@ var MakeStorageDealCmd = &cli.Command{
 			EnvVars: []string{"DEALBOT_MAX_PRICE"},
 			Value:   5e16,
 		},
-	},
+		&cli.Int64Flag{
+			Name:    "start-offset",
+			Usage:   "epochs deal start will be offset from now [5760 (2 days)]",
+			EnvVars: []string{"DEALBOT_START_OFFSET"},
+			Value:   30760,
+		},
+	}...),
 	Action: makeStorageDeal,
 }
 
 func makeStorageDeal(cctx *cli.Context) error {
-	if err := setupLogging(cctx); err != nil {
-		return xerrors.Errorf("setup logging: %w", err)
-	}
-
-	// read dir and assert it exists
-	dataDir := cctx.String("data-dir")
-	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-		return fmt.Errorf("data-dir does not exist: %s", dataDir)
-	}
-
-	nodeDataDir := cctx.String("node-data-dir")
-	if nodeDataDir == "" {
-		nodeDataDir = dataDir
-	}
-
-	// start API to lotus node
-	opener, closer, err := setupLotusAPI(cctx)
+	clientConfig, node, closer, err := setupCLIClient(cctx)
 	if err != nil {
-		return fmt.Errorf("cannot setup lotus api: %w", err)
+		return err
 	}
 	defer closer()
-
-	_ = opener
-
-	node, jsoncloser, err := opener.Open(cctx.Context)
-	if err != nil {
-		return fmt.Errorf("cannot open lotus api: %w", err)
-	}
-	defer jsoncloser()
-
-	// read addresses and assert they are addresses
-	var walletAddress address.Address
-	if cctx.IsSet("wallet") {
-		walletParam := cctx.String("wallet")
-		walletAddress, err = address.NewFromString(walletParam)
-	} else {
-		walletAddress, err = node.WalletDefaultAddress(context.Background())
-	}
-	if err != nil {
-		return fmt.Errorf("wallet is not a Filecoin address: %s, %s", cctx.String("wallet"), err)
-	}
-
-	// get miner address
-	minerParam := cctx.String("miner")
-	minerAddress, err := address.NewFromString(minerParam)
-	if err != nil {
-		return fmt.Errorf("miner is not a Filecoin address: %s, %s", minerParam, err)
-	}
 
 	// Read size parameter and interpret as file size (pre-piece padding)
 	sizeHuman := cctx.String("size")
@@ -114,145 +64,22 @@ func makeStorageDeal(cctx *cli.Context) error {
 	}
 
 	// parse parameters that don't need validation
+	miner := cctx.String("miner")
 	verified := cctx.Bool("verified-deal")
 	fastRetrieval := cctx.Bool("fast-retrieval")
-	startOffset := cctx.Int64("start-offset")
-	maxPrice := abi.NewTokenAmount(cctx.Int64("max-price"))
+	startOffset := cctx.Uint64("start-offset")
+	maxPrice := cctx.Uint64("max-price")
 
-	// get chain head for chain queries and to get height
-	tipSet, err := node.ChainHead(cctx.Context)
-	if err != nil {
-		return err
+	task := tasks.StorageDealTask{
+		Miner:         miner,
+		MaxPriceAFIL:  maxPrice,
+		Size:          size.Bytes(),
+		StartOffset:   startOffset,
+		FastRetrieval: fastRetrieval,
+		Verified:      verified,
 	}
 
-	// retrieve and validate miner price
-	price, err := minerAskPrice(cctx.Context, node, tipSet, minerAddress)
-	if err != nil {
-		return err
-	}
-
-	if price.GreaterThan(maxPrice) {
-		return fmt.Errorf("miner ask price (%v) exceeds max price (%v)", price, maxPrice)
-	}
-
-	fileName := uuid.New().String()
-	filepath := path.Join(dataDir, fileName)
-	file, err := os.Create(filepath)
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
-	}
-	defer file.Close()
-
-	log.Infow("creating deal file", "name", fileName, "size", size, "path", filepath)
-	_, err = io.CopyN(file, rand.Reader, int64(size))
-	if err != nil {
-		return fmt.Errorf("error creating random file for deal: %s, %v", fileName, err)
-	}
-
-	// import the file into the lotus node
-	ref := api.FileRef{
-		Path:  path.Join(nodeDataDir, fileName),
-		IsCAR: false,
-	}
-
-	importRes, err := node.ClientImport(cctx.Context, ref)
-	if err != nil {
-		return err
-	}
-
-	log.Infow("imported deal file, got data cid", "datacid", importRes.Root)
-
-	// Prepare parameters for deal
-	params := &api.StartDealParams{
-		Data: &storagemarket.DataRef{
-			TransferType: storagemarket.TTGraphsync,
-			Root:         importRes.Root,
-		},
-		Wallet:            walletAddress,
-		Miner:             minerAddress,
-		EpochPrice:        price,
-		MinBlocksDuration: 2880 * 180,
-		DealStartEpoch:    tipSet.Height() + abi.ChainEpoch(startOffset),
-		FastRetrieval:     fastRetrieval,
-		VerifiedDeal:      verified,
-	}
-	_ = params
-
-	// start deal process
-	proposalCid, err := node.ClientStartDeal(cctx.Context, params)
-	if err != nil {
-		return err
-	}
-
-	// track updates to deal
-	updates, err := node.ClientGetDealUpdates(cctx.Context)
-	if err != nil {
-		return err
-	}
-
-	lastState := storagemarket.StorageDealUnknown
-	for info := range updates {
-		if proposalCid.Equals(info.ProposalCid) {
-			if info.State != lastState {
-				log.Infow("Deal status",
-					"cid", info.ProposalCid,
-					"piece", info.PieceCID,
-					"state", info.State,
-					"message", info.Message,
-					"provider", info.Provider,
-				)
-				lastState = info.State
-			}
-
-			switch info.State {
-			case storagemarket.StorageDealUnknown:
-			case storagemarket.StorageDealProposalNotFound:
-			case storagemarket.StorageDealProposalRejected:
-			case storagemarket.StorageDealExpired:
-			case storagemarket.StorageDealSlashed:
-			case storagemarket.StorageDealRejecting:
-			case storagemarket.StorageDealFailing:
-			case storagemarket.StorageDealError:
-				// deal failed, exit
-			case storagemarket.StorageDealActive:
-				// deal is on chain, exit
-				for _, stage := range info.DealStages.Stages {
-					log.Infow("Deal stage",
-						"cid", info.ProposalCid,
-						"name", stage.Name,
-						"description", stage.Description,
-						"created", stage.CreatedTime,
-						"expected", stage.ExpectedDuration,
-						"updated", stage.UpdatedTime,
-						"size", info.Size,
-						"duration", info.Duration,
-						"deal_id", info.DealID,
-						"piece_cid", info.PieceCID,
-						"message", info.Message,
-						"provider", info.Provider,
-						"price", info.PricePerEpoch,
-						"verfied", info.Verified,
-					)
-				}
-				return nil
-			}
-		}
-	}
-
-	return nil
-}
-
-func minerAskPrice(ctx context.Context, api api.FullNode, tipSet *types.TipSet, addr address.Address) (abi.TokenAmount, error) {
-	minerInfo, err := api.StateMinerInfo(ctx, addr, tipSet.Key())
-	if err != nil {
-		return big.Zero(), err
-	}
-
-	peerId := *minerInfo.PeerId
-	ask, err := api.ClientQueryAsk(ctx, peerId, addr)
-	if err != nil {
-		return big.Zero(), err
-	}
-
-	return ask.Price, nil
+	return tasks.MakeStorageDeal(cctx.Context, clientConfig, node, task, func(msg string, keysAndValues ...interface{}) {
+		log.Infow(msg, keysAndValues...)
+	})
 }

--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,14 @@
+package config
+
+type EnvConfig struct {
+	Daemon DaemonConfig `toml:"daemon"`
+	Client ClientConfig `toml:"client"`
+}
+
+type DaemonConfig struct {
+	Listen string `toml:"listen"`
+}
+
+type ClientConfig struct {
+	Endpoint string `toml:"endpoint"`
+}

--- a/config/loader.go
+++ b/config/loader.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	EnvDealbotHome = "DEALBOT_HOME"
+
+	// DefaultListenAddr is a host:port value, where we set up an HTTP endpoint.
+	DefaultListenAddr = "localhost:8765"
+
+	// DefaultClientURL is the HTTP(S) endpoint of the server.
+	DefaultClientURL = "http://" + DefaultListenAddr
+)
+
+func (e *EnvConfig) Load() error {
+	// apply fallbacks.
+	e.Daemon.Listen = DefaultListenAddr
+	e.Client.Endpoint = DefaultClientURL
+
+	// calculate home directory; use env var, or fall back to $HOME/testground
+	// otherwise.
+	var home string
+	if v, ok := os.LookupEnv(EnvDealbotHome); ok {
+		// we have an env var.
+		home = v
+	} else {
+		// fallback to $HOME/testground.
+		v, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to obtain user home dir: %w", err)
+		}
+		home = filepath.Join(v, "testground")
+	}
+
+	switch fi, err := os.Stat(home); {
+	case os.IsNotExist(err):
+		//logging.S().Infof("creating home directory at %s", home)
+		if err := os.MkdirAll(home, 0777); err != nil {
+			return fmt.Errorf("failed to create home directory at %s: %w", home, err)
+		}
+	case err == nil:
+		//logging.S().Infof("using home directory: %s", home)
+	case !fi.IsDir():
+		return fmt.Errorf("home path is not a directory %s", home)
+	}
+
+	// parse the .env.toml file, if it exists.
+	//f := filepath.Join(e.dirs.Home(), ".env.toml")
+	//if _, err := os.Stat(f); err == nil {
+	//// try to load the optional .env.toml file
+	//_, err = toml.DecodeFile(f, e)
+	//if err != nil {
+	//return fmt.Errorf("found .env.toml at %s, but failed to parse: %w", f, err)
+	//}
+	////logging.S().Infof(".env.toml loaded from: %s", f)
+	//} else {
+	////logging.S().Infof("no .env.toml found at %s; running with defaults", f)
+	//}
+	return nil
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/dealbot/config"
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
+)
+
+var log = logging.Logger("daemon")
+
+type Daemon struct {
+	server *http.Server
+	l      net.Listener
+	doneCh chan struct{}
+}
+
+func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
+	srv = new(Daemon)
+
+	r := mux.NewRouter().StrictSlash(true)
+
+	// Set a unique request ID.
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Header.Set("X-Request-ID", uuid.New()[:8])
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	//r.HandleFunc("/tasks", srv.listTasksHandler(engine)).Methods("GET")
+
+	srv.doneCh = make(chan struct{})
+	srv.server = &http.Server{
+		Handler:      r,
+		WriteTimeout: 7200 * time.Second,
+		ReadTimeout:  7200 * time.Second,
+	}
+
+	srv.l, err = net.Listen("tcp", cfg.Daemon.Listen)
+	if err != nil {
+		return nil, err
+	}
+
+	return srv, nil
+}
+
+// Serve starts the server and blocks until the server is closed, either
+// explicitly via Shutdown, or due to a fault condition. It propagates the
+// non-nil err return value from http.Serve.
+func (d *Daemon) Serve() error {
+	select {
+	case <-d.doneCh:
+		return fmt.Errorf("tried to reuse a stopped server")
+	default:
+	}
+
+	log.Infow("daemon listening", "addr", d.Addr())
+	return d.server.Serve(d.l)
+}
+
+func (d *Daemon) Addr() string {
+	return d.l.Addr().String()
+}
+
+func (d *Daemon) Port() int {
+	return d.l.Addr().(*net.TCPAddr).Port
+}
+
+func (d *Daemon) Shutdown(ctx context.Context) error {
+	defer close(d.doneCh)
+	return d.server.Shutdown(ctx)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/filecoin-project/lotus v1.5.4-0.20210402110700-eede19fb0b2d
 	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/google/uuid v1.1.2
+	github.com/gorilla/mux v1.7.4
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-log/v2 v2.1.2
@@ -19,6 +20,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.7.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.1
+	github.com/pborman/uuid v1.2.0
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291
 	go.opentelemetry.io/otel v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1247,6 +1247,7 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=

--- a/main.go
+++ b/main.go
@@ -65,8 +65,9 @@ func main() {
 			},
 		}...),
 		Commands: []*cli.Command{
-			commands.MakeStorageDeal,
-			commands.MakeRetrievalDeal,
+			commands.MakeStorageDealCmd,
+			commands.MakeRetrievalDealCmd,
+			commands.DaemonCmd,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,14 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/filecoin-project/dealbot/commands"
 	"github.com/filecoin-project/dealbot/version"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 var log = logging.Logger("dealbot")
@@ -68,6 +67,7 @@ func main() {
 			commands.MakeStorageDealCmd,
 			commands.MakeRetrievalDealCmd,
 			commands.DaemonCmd,
+			commands.CoordinateCmd,
 		},
 	}
 

--- a/tasks/common.go
+++ b/tasks/common.go
@@ -1,0 +1,11 @@
+package tasks
+
+import "github.com/filecoin-project/go-address"
+
+type UpdateStatus func(msg string, keysAndValues ...interface{})
+
+type ClientConfig struct {
+	DataDir       string
+	NodeDataDir   string
+	WalletAddress address.Address
+}

--- a/tasks/retreival_deal.go
+++ b/tasks/retreival_deal.go
@@ -1,0 +1,92 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/ipfs/go-cid"
+)
+
+type RetrievalTask struct {
+	Miner      string
+	PayloadCID string
+	CarExport  bool
+}
+
+func (t *RetrievalTask) FromMap(m map[string]interface{}) error {
+	if ms, ok := m["Miner"]; ok {
+		if s, ok := ms.(string); ok {
+			t.Miner = s
+		}
+	} else {
+		return fmt.Errorf("retrieval task JSON missing `Miner` field: %v", m)
+	}
+
+	if ps, ok := m["PayloadCID"]; ok {
+		if s, ok := ps.(string); ok {
+			t.PayloadCID = s
+		}
+	} else {
+		return fmt.Errorf("retrieval task JSON missing `PayloadCID` field: %v", m)
+	}
+
+	if cs, ok := m["CarExport"]; ok {
+		if b, ok := cs.(bool); ok {
+			t.CarExport = b
+		}
+	}
+
+	return nil
+}
+
+func MakeRetrievalDeal(ctx context.Context, config ClientConfig, node api.FullNode, task RetrievalTask, log UpdateStatus) error {
+	payloadCid, err := cid.Parse(task.PayloadCID)
+	if err != nil {
+		return err
+	}
+
+	minerAddr, err := address.NewFromString(task.Miner)
+	if err != nil {
+		return err
+	}
+
+	offer, err := node.ClientMinerQueryOffer(ctx, minerAddr, payloadCid, nil)
+	if err != nil {
+		return err
+	}
+
+	if offer.Err != "" {
+		return fmt.Errorf("got error in offer: %s", offer.Err)
+	}
+
+	log("got query offer", "root", offer.Root, "piece", offer.Piece, "size", offer.Size, "minprice", offer.MinPrice, "unseal_price", offer.UnsealPrice)
+
+	ref := &api.FileRef{
+		Path:  filepath.Join(config.NodeDataDir, "ret"),
+		IsCAR: task.CarExport,
+	}
+
+	err = node.ClientRetrieve(ctx, offer.Order(config.WalletAddress), ref)
+	if err != nil {
+		return err
+	}
+
+	rdata, err := ioutil.ReadFile(filepath.Join(config.DataDir, "ret"))
+	if err != nil {
+		return err
+	}
+
+	log("retrieval successful", "PayloadCID", task.PayloadCID)
+
+	_ = rdata
+
+	//if carExport {
+	//rdata = ExtractCarData(ctx, rdata, rpath)
+	//}
+
+	return nil
+}

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -1,0 +1,237 @@
+package tasks
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/google/uuid"
+)
+
+func MakeStorageDeal(ctx context.Context, config ClientConfig, node api.FullNode, task StorageDealTask, log UpdateStatus) error {
+	// get chain head for chain queries and to get height
+	tipSet, err := node.ChainHead(ctx)
+	if err != nil {
+		return err
+	}
+
+	// retrieve and validate miner price
+	minerAddress, err := address.NewFromString(task.Miner)
+	if err != nil {
+		return err
+	}
+	price, err := minerAskPrice(ctx, node, tipSet, minerAddress)
+	if err != nil {
+		return err
+	}
+
+	maxPrice := abi.NewTokenAmount(int64(task.MaxPriceAFIL))
+	if price.GreaterThan(maxPrice) {
+		return fmt.Errorf("miner ask price (%v) exceeds max price (%v)", price, maxPrice)
+	}
+
+	fileName := uuid.New().String()
+	filepath := path.Join(config.DataDir, fileName)
+	file, err := os.Create(filepath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer file.Close()
+
+	log("creating deal file", "name", fileName, "size", task.Size, "path", filepath)
+	_, err = io.CopyN(file, rand.Reader, int64(task.Size))
+	if err != nil {
+		return fmt.Errorf("error creating random file for deal: %s, %v", fileName, err)
+	}
+
+	// import the file into the lotus node
+	ref := api.FileRef{
+		Path:  path.Join(config.NodeDataDir, fileName),
+		IsCAR: false,
+	}
+
+	importRes, err := node.ClientImport(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	log("imported deal file, got data cid", "datacid", importRes.Root)
+
+	// Prepare parameters for deal
+	params := &api.StartDealParams{
+		Data: &storagemarket.DataRef{
+			TransferType: storagemarket.TTGraphsync,
+			Root:         importRes.Root,
+		},
+		Wallet:            config.WalletAddress,
+		Miner:             minerAddress,
+		EpochPrice:        price,
+		MinBlocksDuration: 2880 * 180,
+		DealStartEpoch:    tipSet.Height() + abi.ChainEpoch(task.StartOffset),
+		FastRetrieval:     task.FastRetrieval,
+		VerifiedDeal:      task.Verified,
+	}
+	_ = params
+
+	// start deal process
+	proposalCid, err := node.ClientStartDeal(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// track updates to deal
+	updates, err := node.ClientGetDealUpdates(ctx)
+	if err != nil {
+		return err
+	}
+
+	lastState := storagemarket.StorageDealUnknown
+	for info := range updates {
+		if proposalCid.Equals(info.ProposalCid) {
+			if info.State != lastState {
+				log("Deal status",
+					"cid", info.ProposalCid,
+					"piece", info.PieceCID,
+					"state", info.State,
+					"message", info.Message,
+					"provider", info.Provider,
+				)
+				lastState = info.State
+			}
+
+			switch info.State {
+			case storagemarket.StorageDealUnknown:
+			case storagemarket.StorageDealProposalNotFound:
+			case storagemarket.StorageDealProposalRejected:
+			case storagemarket.StorageDealExpired:
+			case storagemarket.StorageDealSlashed:
+			case storagemarket.StorageDealRejecting:
+			case storagemarket.StorageDealFailing:
+			case storagemarket.StorageDealError:
+				// deal failed, exit
+			case storagemarket.StorageDealActive:
+				// deal is on chain, exit
+				for _, stage := range info.DealStages.Stages {
+					log("Deal stage",
+						"cid", info.ProposalCid,
+						"name", stage.Name,
+						"description", stage.Description,
+						"created", stage.CreatedTime,
+						"expected", stage.ExpectedDuration,
+						"updated", stage.UpdatedTime,
+						"size", info.Size,
+						"duration", info.Duration,
+						"deal_id", info.DealID,
+						"piece_cid", info.PieceCID,
+						"message", info.Message,
+						"provider", info.Provider,
+						"price", info.PricePerEpoch,
+						"verfied", info.Verified,
+					)
+				}
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func minerAskPrice(ctx context.Context, api api.FullNode, tipSet *types.TipSet, addr address.Address) (abi.TokenAmount, error) {
+	minerInfo, err := api.StateMinerInfo(ctx, addr, tipSet.Key())
+	if err != nil {
+		return big.Zero(), err
+	}
+
+	peerId := *minerInfo.PeerId
+	ask, err := api.ClientQueryAsk(ctx, peerId, addr)
+	if err != nil {
+		return big.Zero(), err
+	}
+
+	return ask.Price, nil
+}
+
+type StorageDealTask struct {
+	Miner         string
+	MaxPriceAFIL  uint64
+	Size          uint64
+	StartOffset   uint64
+	FastRetrieval bool
+	Verified      bool
+}
+
+func (t *StorageDealTask) FromMap(m map[string]interface{}) error {
+	if ms, ok := m["Miner"]; ok {
+		if s, ok := ms.(string); ok {
+			t.Miner = s
+		} else {
+			return fmt.Errorf("`Miner` field is not a string: %v, %v", ms, m)
+		}
+	} else {
+		return fmt.Errorf("storage task JSON missing `Miner` field: %v", m)
+	}
+
+	if ns, ok := m["MaxPriceAFIL"]; ok {
+		if n, ok := ns.(int); ok {
+			t.MaxPriceAFIL = uint64(n)
+		} else {
+			return fmt.Errorf("`MaxPriceAFIL` field is not an int: %v, %v", ns, m)
+		}
+	} else {
+		t.MaxPriceAFIL = 5e16
+	}
+
+	if ns, ok := m["Size"]; ok {
+		if n, ok := ns.(string); ok {
+			var size datasize.ByteSize
+			err := size.UnmarshalText([]byte(n))
+			if err != nil {
+				return fmt.Errorf("size is not a recognizable byte size: %s, %v", n, m)
+			}
+			t.Size = size.Bytes()
+		} else {
+			return fmt.Errorf("`Size` field is not a string: %v, %v", ns, m)
+		}
+	} else {
+		t.MaxPriceAFIL = 1e6
+	}
+
+	if ns, ok := m["StartOffset"]; ok {
+		if n, ok := ns.(int); ok {
+			t.StartOffset = uint64(n)
+		} else {
+			return fmt.Errorf("`StartOffset` field is not an int: %v, %v", ns, m)
+		}
+	} else {
+		t.StartOffset = 30760
+	}
+
+	if cs, ok := m["FastRetrieval"]; ok {
+		if b, ok := cs.(bool); ok {
+			t.FastRetrieval = b
+		} else {
+			return fmt.Errorf("`FastRetrieval` field is not a bool: %v, %v", cs, m)
+		}
+	}
+
+	if cs, ok := m["Verified"]; ok {
+		if b, ok := cs.(bool); ok {
+			t.Verified = b
+		} else {
+			return fmt.Errorf("`Verified` field is not a bool: %v, %v", cs, m)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR is adding a `daemon` command, with the idea that `dealbot daemon` would run a single HTTP server to listen for commands from the `dealbot controller`.

`dealbot daemon` should accept `tasks` from the `dealbot controller` and report back results (directly writing to stdout, and probably shorter response to the `dealbot controller`.

---

This is still in heavy WIP.