### PR TITLE
Setup Metrics Interface

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -68,6 +68,12 @@ var ControllerFlags = []cli.Flag{
 		Aliases: []string{"l"},
 		EnvVars: []string{"DEALBOT_LISTEN"},
 	}),
+	altsrc.NewStringFlag(&cli.StringFlag{
+		Name:    "metrics",
+		Usage:   "value of 'prometheus' or 'log'",
+		Aliases: []string{"l"},
+		EnvVars: []string{"DEALBOT_METRICS"},
+	}),
 }
 
 var AllFlags = append(DealFlags, append(SingleTaskFlags, append(DaemonFlags, ControllerFlags...)...)...)

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -29,6 +29,11 @@ func New(ctx *cli.Context) *Client {
 
 	log.Infow("dealbot controller client initialized", "addr", endpoint)
 
+	return NewFromEndpoint(endpoint)
+}
+
+// NewFromEndpoint returns an API client at the given endpoint
+func NewFromEndpoint(endpoint string) *Client {
 	return &Client{
 		client:   &http.Client{},
 		endpoint: endpoint,

--- a/controller/http_test.go
+++ b/controller/http_test.go
@@ -1,0 +1,103 @@
+package controller_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/dealbot/controller"
+	"github.com/filecoin-project/dealbot/controller/client"
+	"github.com/filecoin-project/dealbot/metrics/testrecorder"
+	"github.com/filecoin-project/dealbot/tasks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerHTTPInterface(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	apiClient := client.NewFromEndpoint("http://localhost:3333")
+	recorder := testrecorder.NewTestMetricsRecorder()
+	listener, err := net.Listen("tcp", "localhost:3333")
+	require.NoError(t, err)
+	c := controller.NewWithDependencies(listener, recorder)
+	serveErr := make(chan error, 1)
+	go func() {
+		err := c.Serve()
+		select {
+		case <-ctx.Done():
+		case serveErr <- err:
+		}
+	}()
+	currentTasks, err := apiClient.ListTasks(ctx)
+	require.NoError(t, err)
+	require.Len(t, currentTasks, 4)
+
+	// update a task
+	_, status, err := apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
+		UUID:     currentTasks[0].UUID,
+		WorkedBy: "dealbot 1",
+		Status:   tasks.InProgress,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	currentTasks, err = apiClient.ListTasks(ctx)
+	require.NoError(t, err)
+	require.Equal(t, tasks.InProgress, currentTasks[0].Status)
+	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
+
+	// update but from the wrong dealbot
+	_, status, err = apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
+		UUID:     currentTasks[0].UUID,
+		WorkedBy: "dealbot 2",
+		Status:   tasks.Successful,
+	})
+	require.NoError(t, err)
+	// request fails
+	require.Equal(t, http.StatusBadRequest, status)
+	currentTasks, err = apiClient.ListTasks(ctx)
+	require.NoError(t, err)
+	// status should not change
+	require.Equal(t, tasks.InProgress, currentTasks[0].Status)
+	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
+
+	// update again
+	_, status, err = apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
+		UUID:     currentTasks[0].UUID,
+		WorkedBy: "dealbot 1",
+		Status:   tasks.Successful,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	currentTasks, err = apiClient.ListTasks(ctx)
+	require.NoError(t, err)
+	require.Equal(t, tasks.Successful, currentTasks[0].Status)
+	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
+
+	// update a different task
+	_, status, err = apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
+		UUID:     currentTasks[1].UUID,
+		WorkedBy: "dealbot 2",
+		Status:   tasks.Successful,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	currentTasks, err = apiClient.ListTasks(ctx)
+	require.NoError(t, err)
+	require.Equal(t, tasks.Successful, currentTasks[1].Status)
+	require.Equal(t, "dealbot 2", currentTasks[1].WorkedBy)
+
+	err = c.Shutdown(ctx)
+	require.NoError(t, err)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("no return from serve call")
+	case err = <-serveErr:
+		require.EqualError(t, err, http.ErrServerClosed.Error())
+	}
+
+	recorder.AssertExactObservedStatuses(t, currentTasks[0].UUID, tasks.InProgress, tasks.Successful)
+	recorder.AssertExactObservedStatuses(t, currentTasks[1].UUID, tasks.Successful)
+}

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -34,7 +34,7 @@ func (c *Controller) updateTaskHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = State.Update(req)
+	err = State.Update(req, c.metricsRecorder)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/go.mod
+++ b/go.mod
@@ -16,13 +16,10 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/pborman/uuid v1.2.0
 	github.com/prometheus/client_golang v1.6.0
+	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
-	github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291
-	go.opencensus.io v0.22.5
-	go.opentelemetry.io/otel v0.12.0
-	go.uber.org/zap v1.16.0
+	github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,13 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.1
+	github.com/pborman/uuid v1.2.0
+	github.com/prometheus/client_golang v1.6.0
 	github.com/urfave/cli/v2 v2.3.0
-	github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291 // indirect
+	github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291
+	go.opencensus.io v0.22.5
+	go.opentelemetry.io/otel v0.12.0
+	go.uber.org/zap v1.16.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
 

--- a/metrics/interface.go
+++ b/metrics/interface.go
@@ -9,10 +9,5 @@ import (
 // MetricsRecorder abstracts the process of recording metrics for tasks
 type MetricsRecorder interface {
 	Handler() http.Handler
-	ObserveTask(tasks.Task) (TaskObserver, error)
-}
-
-// TaskObserver records status updates for a given task
-type TaskObserver interface {
-	RecordStatusUpdate(status tasks.Status) error
+	ObserveTask(*tasks.Task) error
 }

--- a/metrics/interface.go
+++ b/metrics/interface.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/filecoin-project/dealbot/tasks"
+)
+
+// MetricsRecorder abstracts the process of recording metrics for tasks
+type MetricsRecorder interface {
+	Handler() http.Handler
+	ObserveTask(tasks.Task) (TaskObserver, error)
+}
+
+// TaskObserver records status updates for a given task
+type TaskObserver interface {
+	RecordStatusUpdate(status tasks.Status) error
+}

--- a/metrics/labels.go
+++ b/metrics/labels.go
@@ -1,0 +1,15 @@
+package metrics
+
+// Labels for fields in metrics
+const (
+	UUID            = "uuid"
+	Status          = "status"
+	Miner           = "miner"
+	MaxPriceAttoFIL = "max_price_atto_fil"
+	Size            = "size"
+	StartOffset     = "start_offset"
+	FastRetrieval   = "fast_retrieval"
+	Verified        = "verified"
+	PayloadCID      = "payload_cid"
+	CARExport       = "car_export"
+)

--- a/metrics/log/log.go
+++ b/metrics/log/log.go
@@ -32,7 +32,7 @@ func (lr *logRecorder) ObserveTask(task *tasks.Task) error {
 			metrics.Miner, task.RetrievalTask.Miner,
 			metrics.PayloadCID, task.RetrievalTask.PayloadCID,
 			metrics.CARExport, task.RetrievalTask.CARExport,
-			metrics.Status, tasks.StatusNames[task.Status],
+			metrics.Status, task.Status,
 			"duration (ms)", duration)
 		return nil
 	}
@@ -45,7 +45,7 @@ func (lr *logRecorder) ObserveTask(task *tasks.Task) error {
 			metrics.StartOffset, task.StorageTask.StartOffset,
 			metrics.FastRetrieval, task.StorageTask.FastRetrieval,
 			metrics.Verified, task.StorageTask.Verified,
-			metrics.Status, tasks.StatusNames[task.Status],
+			metrics.Status, task.Status,
 			"duration (ms)", duration)
 		return nil
 	}

--- a/metrics/log/log.go
+++ b/metrics/log/log.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/dealbot/metrics"
+	"github.com/filecoin-project/dealbot/tasks"
+	logging "github.com/ipfs/go-log/v2"
+	"go.uber.org/zap"
+)
+
+type logRecorder struct {
+	log *logging.ZapEventLogger
+}
+
+// NewLogMetricsRecorder returns a metrics recorder that simply logs metrics
+func NewLogMetricsRecorder(log *logging.ZapEventLogger) metrics.MetricsRecorder {
+	return &logRecorder{log}
+}
+
+func (lr *logRecorder) Handler() http.Handler {
+	return nil
+}
+
+func (lr *logRecorder) ObserveTask(task tasks.Task) (metrics.TaskObserver, error) {
+	if task.RetrievalTask != nil {
+		return &taskObserver{
+			msg:       "retrieval task",
+			startTime: time.Now(),
+			log: lr.log.With(
+				metrics.UUID, task.UUID,
+				metrics.Miner, task.RetrievalTask.Miner,
+				metrics.PayloadCID, task.RetrievalTask.PayloadCID,
+				metrics.CARExport, task.RetrievalTask.CARExport),
+		}, nil
+	}
+	if task.StorageTask != nil {
+		return &taskObserver{
+			msg:       "storage task",
+			startTime: time.Now(),
+			log: lr.log.With(
+				metrics.UUID, task.UUID,
+				metrics.Miner, task.StorageTask.Miner,
+				metrics.MaxPriceAttoFIL, task.StorageTask.MaxPriceAttoFIL,
+				metrics.Size, task.StorageTask.Size,
+				metrics.StartOffset, task.StorageTask.StartOffset,
+				metrics.FastRetrieval, task.StorageTask.FastRetrieval,
+				metrics.Verified, task.StorageTask.Verified),
+		}, nil
+	}
+	return nil, fmt.Errorf("Cannot observe task: %s, both tasks are nil", task.UUID)
+}
+
+type taskObserver struct {
+	startTime time.Time
+	msg       string
+	log       *zap.SugaredLogger
+}
+
+func (to *taskObserver) RecordStatusUpdate(status tasks.Status) error {
+	duration := time.Since(to.startTime).Milliseconds()
+	to.log.Infow(to.msg, "status", tasks.StatusNames[status], "duration (ms)", duration)
+	return nil
+}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -1,0 +1,128 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/filecoin-project/dealbot/metrics"
+	"github.com/filecoin-project/dealbot/tasks"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	// Namespace is the name space for metrics exported to prometheus
+	Namespace = "dealbot"
+	// StorageTasks is the subsystem to record storage task metrics
+	StorageTasks = "storage_tasks"
+	// RetrievalTasks is the subsystem to record retrieval tasks metrics
+	RetrievalTasks = "retrieval_tasks"
+	// Duration is the name of our metric -- the duration it took to get to the given status
+	Duration = "duration"
+	// Help is a description of what duration measures
+	Help = "task duration in milliseconds to get to the specified status"
+)
+
+// Buckets are the default histogram buckets for measuring duration
+// (essentially, second, minute, hour, day, and everything else)
+var Buckets = []float64{
+	float64(time.Second.Milliseconds()),
+	float64(time.Minute.Milliseconds()),
+	float64(time.Hour.Milliseconds()),
+	float64(time.Hour.Milliseconds() * 24),
+}
+
+// StorageLabels are the ways we categorize storage tasks
+// TODO: do we want ALL of these labels? It will mean a LOT of data
+var StorageLabels = []string{metrics.UUID, metrics.Status, metrics.Miner, metrics.MaxPriceAttoFIL, metrics.Size, metrics.StartOffset, metrics.FastRetrieval, metrics.Verified}
+
+// RetrievalLabels are the way we categorize retrieval tasks
+// TODO: do we want ALL of these labels? Do PayloadCID/CARExport matter here?
+var RetrievalLabels = []string{metrics.UUID, metrics.Status, metrics.Miner, metrics.PayloadCID, metrics.CARExport}
+
+type prometheusMetricsRecorder struct {
+	storageVec   *prometheus.HistogramVec
+	retrievalVec *prometheus.HistogramVec
+}
+
+// PrometheusMetricsRecord returns a recorder that is connected to prometheus
+func NewPrometheusMetricsRecorder() metrics.MetricsRecorder {
+	return &prometheusMetricsRecorder{
+		storageVec: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: StorageTasks,
+			Name:      Duration,
+			Help:      Help,
+			Buckets:   Buckets,
+		}, StorageLabels),
+		retrievalVec: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: RetrievalTasks,
+			Name:      Duration,
+			Help:      Help,
+			Buckets:   Buckets,
+		}, RetrievalLabels),
+	}
+}
+
+func (pmr *prometheusMetricsRecorder) Handler() http.Handler {
+	return promhttp.Handler()
+}
+
+func (pmr *prometheusMetricsRecorder) ObserveTask(task tasks.Task) (metrics.TaskObserver, error) {
+	if task.RetrievalTask != nil {
+		return pmr.toRetrievalTaskObserver(task)
+	}
+	if task.StorageTask != nil {
+		return pmr.toStorageTaskObserver(task)
+	}
+	return nil, fmt.Errorf("Cannot observe task: %s, both tasks are nil", task.UUID)
+}
+
+func (pmr *prometheusMetricsRecorder) toStorageTaskObserver(task tasks.Task) (*taskObserver, error) {
+	start := time.Now()
+	observer, err := pmr.storageVec.CurryWith(prometheus.Labels{
+		metrics.UUID:            task.UUID,
+		metrics.Miner:           task.StorageTask.Miner,
+		metrics.MaxPriceAttoFIL: strconv.FormatUint(task.StorageTask.MaxPriceAttoFIL, 10),
+		metrics.Size:            strconv.FormatUint(task.StorageTask.Size, 10),
+		metrics.StartOffset:     strconv.FormatUint(task.StorageTask.StartOffset, 10),
+		metrics.FastRetrieval:   strconv.FormatBool(task.StorageTask.FastRetrieval),
+		metrics.Verified:        strconv.FormatBool(task.StorageTask.Verified),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &taskObserver{observer: observer, startTime: start}, nil
+}
+
+func (pmr *prometheusMetricsRecorder) toRetrievalTaskObserver(task tasks.Task) (*taskObserver, error) {
+	start := time.Now()
+	observer, err := pmr.retrievalVec.CurryWith(prometheus.Labels{
+		metrics.UUID:       task.UUID,
+		metrics.Miner:      task.RetrievalTask.Miner,
+		metrics.PayloadCID: task.RetrievalTask.PayloadCID,
+		metrics.CARExport:  strconv.FormatBool(task.RetrievalTask.CARExport),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &taskObserver{observer: observer, startTime: start}, nil
+}
+
+type taskObserver struct {
+	observer  prometheus.ObserverVec
+	startTime time.Time
+}
+
+func (to *taskObserver) RecordStatusUpdate(status tasks.Status) error {
+	observer, err := to.observer.GetMetricWith(prometheus.Labels{metrics.Status: tasks.StatusNames[status]})
+	if err != nil {
+		return err
+	}
+	observer.Observe(float64(time.Since(to.startTime).Milliseconds()))
+	return nil
+}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -92,7 +92,7 @@ func (pmr *prometheusMetricsRecorder) observeStorageTask(task *tasks.Task) error
 		metrics.StartOffset:     strconv.FormatUint(task.StorageTask.StartOffset, 10),
 		metrics.FastRetrieval:   strconv.FormatBool(task.StorageTask.FastRetrieval),
 		metrics.Verified:        strconv.FormatBool(task.StorageTask.Verified),
-		metrics.Status:          tasks.StatusNames[task.Status],
+		metrics.Status:          task.Status.String(),
 	})
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (pmr *prometheusMetricsRecorder) observeRetrievalTask(task *tasks.Task) err
 		metrics.Miner:      task.RetrievalTask.Miner,
 		metrics.PayloadCID: task.RetrievalTask.PayloadCID,
 		metrics.CARExport:  strconv.FormatBool(task.RetrievalTask.CARExport),
-		metrics.Status:     tasks.StatusNames[task.Status],
+		metrics.Status:     task.Status.String(),
 	})
 	if err != nil {
 		return err

--- a/metrics/testrecorder/testrecorder.go
+++ b/metrics/testrecorder/testrecorder.go
@@ -1,0 +1,62 @@
+package testrecorder
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/filecoin-project/dealbot/metrics"
+	"github.com/filecoin-project/dealbot/tasks"
+	"github.com/stretchr/testify/assert"
+)
+
+type taskStatuses struct {
+	statuses []tasks.Status
+}
+
+// TestMetricsRecorder recorder is a metrics recorder that allows you to assert expected behavior for the metrics library
+type TestMetricsRecorder struct {
+	tasks map[string]*taskStatuses
+}
+
+// NewTestMetricsRecorder constructs a new test metrics recorder
+func NewTestMetricsRecorder() *TestMetricsRecorder {
+	return &TestMetricsRecorder{
+		tasks: make(map[string]*taskStatuses),
+	}
+}
+
+func (tr *TestMetricsRecorder) Handler() http.Handler {
+	return nil
+}
+
+func (tr *TestMetricsRecorder) ObserveTask(task tasks.Task) (metrics.TaskObserver, error) {
+	existing, ok := tr.tasks[task.UUID]
+	if ok {
+		return existing, nil
+	}
+	ts := &taskStatuses{statuses: []tasks.Status{task.Status}}
+	tr.tasks[task.UUID] = ts
+	return ts, nil
+}
+
+// AssertObservedStatuses asserts that the given statuses were among those observed for the given task
+func (tr *TestMetricsRecorder) AssertObservedStatuses(t *testing.T, uuid string, expectedStatuses ...tasks.Status) {
+	ts, ok := tr.tasks[uuid]
+	assert.True(t, ok, "no statuses for tasks")
+	for _, status := range expectedStatuses {
+		assert.Contains(t, ts.statuses, status)
+	}
+}
+
+// AssertExactObservedStatuses asserts the the expected statuses we the exact statuses observed for the given task,
+// in order, with no other statuses observed
+func (tr *TestMetricsRecorder) AssertExactObservedStatuses(t *testing.T, uuid string, expectedStatuses ...tasks.Status) {
+	ts, ok := tr.tasks[uuid]
+	assert.True(t, ok, "no statuses for tasks")
+	assert.Equal(t, expectedStatuses, ts.statuses)
+}
+
+func (ts *taskStatuses) RecordStatusUpdate(status tasks.Status) error {
+	ts.statuses = append(ts.statuses, status)
+	return nil
+}

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -43,9 +43,13 @@ const (
 	Failed
 )
 
-var StatusNames = map[Status]string{
+var statusNames = map[Status]string{
 	Available:  "Available",
 	InProgress: "InProgress",
 	Successful: "Successful",
 	Failed:     "Failed",
+}
+
+func (s Status) String() string {
+	return statusNames[s]
 }

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"time"
+
 	"github.com/filecoin-project/go-address"
 	logging "github.com/ipfs/go-log/v2"
 )
@@ -14,10 +16,10 @@ type NodeConfig struct {
 }
 
 type Task struct {
-	UUID     string `json:"uuid"`
-	Status   Status `json:"status"`
-	WorkedBy string `json:"worked_by,omitempty"` // which dealbot works on that task
-
+	UUID          string         `json:"uuid"`
+	Status        Status         `json:"status"`
+	WorkedBy      string         `json:"worked_by,omitempty"`  // which dealbot works on that task
+	StartedAt     time.Time      `json:"started_at,omitempty"` // the time the task was assigned first assigned to the dealbot
 	RetrievalTask *RetrievalTask `json:"retrieval_task,omitempty"`
 	StorageTask   *StorageTask   `json:"storage_task,omitempty"`
 }

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -40,3 +40,10 @@ const (
 	Successful
 	Failed
 )
+
+var StatusNames = map[Status]string{
+	Available:  "Available",
+	InProgress: "InProgress",
+	Successful: "Successful",
+	Failed:     "Failed",
+}


### PR DESCRIPTION
# Goals

Setup a framework for exporting metrics

# Implementation

- Define an abstract interface for observing tasks - rather than attempt to wrangle one of the Open* frameworks, I wrote a high level interface that can just record observations on a task when it updates.
- I wrote three implementations here:
   - One that will record metrics for Prometheus
   - One that will just generate logs for the controller
   - One that is just a test version used to assert observations
- The prometheus one needs further setup and testing -- I have yet to build a docker for prometheus itself, but this PR is growing quickly and I want to get feedback before I go further
- My assumption is: you'd run the log version in dev, the prometheus version in prod, allowing us to avoid having devs running prometheus either on their machine or on a test node
- I also updated the logic of the update task command so it accepts further tasks updates IF and only if the same deal bot that assigned itself submits the update
- I went ahead and wrote the a controller HTTP test that tests the interactions with the controller HTTP server, using the api client, absent the rest of the system. This seems like a good place to start in terms of isolated testing (though it sits between unit and integration testing, I think it's a good boundary to work with)