### PR TITLE
fix nil ptr dereference

### DIFF
--- a/commands/storage_deal.go
+++ b/commands/storage_deal.go
@@ -42,7 +42,7 @@ var MakeStorageDealCmd = &cli.Command{
 		},
 		&cli.Int64Flag{
 			Name:    "start-offset",
-			Usage:   "epochs deal start will be offset from now [5760 (2 days)]",
+			Usage:   "epochs deal start will be offset from now [30760 (10 days)]",
 			EnvVars: []string{"DEALBOT_START_OFFSET"},
 			Value:   30760,
 		},

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -109,11 +109,15 @@ func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, 
 		return err
 	}
 
+	log("got proposal cid", "cid", proposalCid)
+
 	// track updates to deal
 	updates, err := node.ClientGetDealUpdates(ctx)
 	if err != nil {
 		return err
 	}
+
+	log("got deal updates channel")
 
 	lastState := storagemarket.StorageDealUnknown
 	for info := range updates {
@@ -156,6 +160,10 @@ func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, 
 }
 
 func logStages(info api.DealInfo, log UpdateStatus) {
+	if info.DealStages == nil {
+		log("Deal stages is nil")
+	}
+
 	for _, stage := range info.DealStages.Stages {
 		log("Deal stage",
 			"cid", info.ProposalCid,

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -162,6 +162,7 @@ func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, 
 func logStages(info api.DealInfo, log UpdateStatus) {
 	if info.DealStages == nil {
 		log("Deal stages is nil")
+		return
 	}
 
 	for _, stage := range info.DealStages.Stages {


### PR DESCRIPTION
This PR is:
1. Fixing a nil pointer dereference.
2. Fixing the description of the `start-offset` flag.
3. Adding two log lines so that we debug which Lotus API is blocking for an unknown reason.