### PR TITLE
Fix controller command line arg

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -71,7 +71,7 @@ var ControllerFlags = []cli.Flag{
 	altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "metrics",
 		Usage:   "value of 'prometheus' or 'log'",
-		Aliases: []string{"l"},
+		Aliases: []string{"m"},
 		EnvVars: []string{"DEALBOT_METRICS"},
 	}),
 }


### PR DESCRIPTION
# Goals

Pretend I didn't break the build when I rebased the metrics branch

# Implementation

fix controller command crashing due to common abbreviation