### PR TITLE
Add task ingestion

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -16,6 +16,14 @@ import (
 
 var log = logging.Logger("controller")
 
+type ErrRequestFailed struct {
+	Code int
+}
+
+func (e ErrRequestFailed) Error() string {
+	return fmt.Sprintf("Request failed: %s", http.StatusText(e.Code))
+}
+
 // Client is the API client that performs all operations
 // against the dealbot controller.
 type Client struct {
@@ -49,13 +57,13 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) ListTasks(ctx context.Context) ([]*tasks.Task, error) {
-	reader, _, err := c.request(ctx, "GET", "/tasks", nil)
+	resp, err := c.request(ctx, "GET", "/tasks", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var res []*tasks.Task
-	err = json.NewDecoder(reader).Decode(&res)
+	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
 		return nil, err
 	}
@@ -63,19 +71,102 @@ func (c *Client) ListTasks(ctx context.Context) ([]*tasks.Task, error) {
 	return res, nil
 }
 
-func (c *Client) UpdateTask(ctx context.Context, UUID string, r *UpdateTaskRequest) (io.ReadCloser, int, error) {
+func (c *Client) UpdateTask(ctx context.Context, UUID string, r *UpdateTaskRequest) (*tasks.Task, error) {
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(r)
 	if err != nil {
-		return nil, -1, err
+		return nil, err
 	}
 
-	return c.request(ctx, "PATCH", "/tasks/"+UUID, bytes.NewReader(body.Bytes()))
+	resp, err := c.request(ctx, "PATCH", "/tasks/"+UUID, bytes.NewReader(body.Bytes()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrRequestFailed{resp.StatusCode}
+	}
+
+	var res *tasks.Task
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
-func (c *Client) request(ctx context.Context, method string, path string, body io.Reader, headers ...string) (io.ReadCloser, int, error) {
+func (c *Client) GetTask(ctx context.Context, UUID string) (*tasks.Task, error) {
+	resp, err := c.request(ctx, "GET", "/tasks/"+UUID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrRequestFailed{resp.StatusCode}
+	}
+
+	var res *tasks.Task
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (c *Client) CreateStorageTask(ctx context.Context, storageTask *tasks.StorageTask) (*tasks.Task, error) {
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(storageTask)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.request(ctx, "POST", "/tasks/storage", bytes.NewReader(body.Bytes()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, ErrRequestFailed{resp.StatusCode}
+	}
+
+	var res *tasks.Task
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (c *Client) CreateRetrievalTask(ctx context.Context, retrievalTask *tasks.RetrievalTask) (*tasks.Task, error) {
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(retrievalTask)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.request(ctx, "POST", "/tasks/retrieval", bytes.NewReader(body.Bytes()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, ErrRequestFailed{resp.StatusCode}
+	}
+
+	var res *tasks.Task
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (c *Client) request(ctx context.Context, method string, path string, body io.Reader, headers ...string) (*http.Response, error) {
 	if len(headers)%2 != 0 {
-		return nil, -1, fmt.Errorf("headers must be tuples: key1, value1, key2, value2")
+		return nil, fmt.Errorf("headers must be tuples: key1, value1, key2, value2")
 	}
 	req, err := http.NewRequest(method, c.endpoint+path, body)
 	req = req.WithContext(ctx)
@@ -85,11 +176,7 @@ func (c *Client) request(ctx context.Context, method string, path string, body i
 	}
 
 	if err != nil {
-		return nil, -1, err
+		return nil, err
 	}
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, -1, err
-	}
-	return resp.Body, resp.StatusCode, nil
+	return c.client.Do(req)
 }

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -63,14 +63,14 @@ func (c *Client) ListTasks(ctx context.Context) ([]*tasks.Task, error) {
 	return res, nil
 }
 
-func (c *Client) UpdateTask(ctx context.Context, r *UpdateTaskRequest) (io.ReadCloser, int, error) {
+func (c *Client) UpdateTask(ctx context.Context, UUID string, r *UpdateTaskRequest) (io.ReadCloser, int, error) {
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(r)
 	if err != nil {
 		return nil, -1, err
 	}
 
-	return c.request(ctx, "PUT", "/task", bytes.NewReader(body.Bytes()))
+	return c.request(ctx, "PATCH", "/tasks/"+UUID, bytes.NewReader(body.Bytes()))
 }
 
 func (c *Client) request(ctx context.Context, method string, path string, body io.Reader, headers ...string) (io.ReadCloser, int, error) {

--- a/controller/client/model.go
+++ b/controller/client/model.go
@@ -3,7 +3,6 @@ package client
 import "github.com/filecoin-project/dealbot/tasks"
 
 type UpdateTaskRequest struct {
-	UUID     string       `json:"uuid"`
 	Status   tasks.Status `json:"status"`
 	WorkedBy string       `json:"worked_by,omitempty"` // which dealbot works on that task
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -56,8 +56,11 @@ func NewWithDependencies(listener net.Listener, recorder metrics.MetricsRecorder
 	})
 
 	r.HandleFunc("/tasks", srv.getTasksHandler).Methods("GET")
+	r.HandleFunc("/tasks/storage", srv.newStorageTaskHandler).Methods("POST")
+	r.HandleFunc("/tasks/retrieval", srv.newRetrievalTaskHandler).Methods("POST")
 	r.HandleFunc("/status", srv.reportStatusHandler).Methods("POST")
 	r.HandleFunc("/tasks/{uuid}", srv.updateTaskHandler).Methods("PATCH")
+	r.HandleFunc("/tasks/{uuid}", srv.getTaskHandler).Methods("GET")
 	metricsHandler := recorder.Handler()
 	if metricsHandler != nil {
 		r.Handle("/metrics", metricsHandler)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -57,7 +57,7 @@ func NewWithDependencies(listener net.Listener, recorder metrics.MetricsRecorder
 
 	r.HandleFunc("/tasks", srv.getTasksHandler).Methods("GET")
 	r.HandleFunc("/status", srv.reportStatusHandler).Methods("POST")
-	r.HandleFunc("/task", srv.updateTaskHandler).Methods("PUT")
+	r.HandleFunc("/tasks/{uuid}", srv.updateTaskHandler).Methods("PATCH")
 	metricsHandler := recorder.Handler()
 	if metricsHandler != nil {
 		r.Handle("/metrics", metricsHandler)

--- a/controller/http_test.go
+++ b/controller/http_test.go
@@ -36,8 +36,7 @@ func TestControllerHTTPInterface(t *testing.T) {
 	require.Len(t, currentTasks, 4)
 
 	// update a task
-	_, status, err := apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
-		UUID:     currentTasks[0].UUID,
+	_, status, err := apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
 		WorkedBy: "dealbot 1",
 		Status:   tasks.InProgress,
 	})
@@ -49,8 +48,7 @@ func TestControllerHTTPInterface(t *testing.T) {
 	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
 
 	// update but from the wrong dealbot
-	_, status, err = apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
-		UUID:     currentTasks[0].UUID,
+	_, status, err = apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
 		WorkedBy: "dealbot 2",
 		Status:   tasks.Successful,
 	})
@@ -64,8 +62,7 @@ func TestControllerHTTPInterface(t *testing.T) {
 	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
 
 	// update again
-	_, status, err = apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
-		UUID:     currentTasks[0].UUID,
+	_, status, err = apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
 		WorkedBy: "dealbot 1",
 		Status:   tasks.Successful,
 	})
@@ -77,8 +74,7 @@ func TestControllerHTTPInterface(t *testing.T) {
 	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
 
 	// update a different task
-	_, status, err = apiClient.UpdateTask(ctx, &client.UpdateTaskRequest{
-		UUID:     currentTasks[1].UUID,
+	_, status, err = apiClient.UpdateTask(ctx, currentTasks[1].UUID, &client.UpdateTaskRequest{
 		WorkedBy: "dealbot 2",
 		Status:   tasks.Successful,
 	})

--- a/controller/http_test.go
+++ b/controller/http_test.go
@@ -16,84 +16,160 @@ import (
 
 func TestControllerHTTPInterface(t *testing.T) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-	apiClient := client.NewFromEndpoint("http://localhost:3333")
-	recorder := testrecorder.NewTestMetricsRecorder()
-	listener, err := net.Listen("tcp", "localhost:3333")
-	require.NoError(t, err)
-	c := controller.NewWithDependencies(listener, recorder)
-	serveErr := make(chan error, 1)
-	go func() {
-		err := c.Serve()
-		select {
-		case <-ctx.Done():
-		case serveErr <- err:
-		}
-	}()
-	currentTasks, err := apiClient.ListTasks(ctx)
-	require.NoError(t, err)
-	require.Len(t, currentTasks, 4)
+	testCases := map[string]struct {
+		runRequests  func(ctx context.Context, t *testing.T, apiClient *client.Client)
+		checkMetrics func(t *testing.T, currentTasks []*tasks.Task, recorder *testrecorder.TestMetricsRecorder)
+	}{
+		"updating tasks": {
+			runRequests: func(ctx context.Context, t *testing.T, apiClient *client.Client) {
+				currentTasks, err := apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				require.Len(t, currentTasks, 4)
 
-	// update a task
-	_, status, err := apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
-		WorkedBy: "dealbot 1",
-		Status:   tasks.InProgress,
-	})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, status)
-	currentTasks, err = apiClient.ListTasks(ctx)
-	require.NoError(t, err)
-	require.Equal(t, tasks.InProgress, currentTasks[0].Status)
-	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
+				// update a task
+				task, err := apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
+					WorkedBy: "dealbot 1",
+					Status:   tasks.InProgress,
+				})
+				require.Equal(t, tasks.InProgress, task.Status)
+				require.NoError(t, err)
+				currentTasks, err = apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				require.Equal(t, tasks.InProgress, currentTasks[0].Status)
+				require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
 
-	// update but from the wrong dealbot
-	_, status, err = apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
-		WorkedBy: "dealbot 2",
-		Status:   tasks.Successful,
-	})
-	require.NoError(t, err)
-	// request fails
-	require.Equal(t, http.StatusBadRequest, status)
-	currentTasks, err = apiClient.ListTasks(ctx)
-	require.NoError(t, err)
-	// status should not change
-	require.Equal(t, tasks.InProgress, currentTasks[0].Status)
-	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
+				// update but from the wrong dealbot
+				task, err = apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
+					WorkedBy: "dealbot 2",
+					Status:   tasks.Successful,
+				})
+				// request fails
+				require.EqualError(t, err, client.ErrRequestFailed{Code: http.StatusBadRequest}.Error())
+				require.Nil(t, task)
+				currentTasks, err = apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				// status should not change
+				require.Equal(t, tasks.InProgress, currentTasks[0].Status)
+				require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
 
-	// update again
-	_, status, err = apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
-		WorkedBy: "dealbot 1",
-		Status:   tasks.Successful,
-	})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, status)
-	currentTasks, err = apiClient.ListTasks(ctx)
-	require.NoError(t, err)
-	require.Equal(t, tasks.Successful, currentTasks[0].Status)
-	require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
+				// update again
+				task, err = apiClient.UpdateTask(ctx, currentTasks[0].UUID, &client.UpdateTaskRequest{
+					WorkedBy: "dealbot 1",
+					Status:   tasks.Successful,
+				})
+				require.NoError(t, err)
+				require.Equal(t, tasks.Successful, task.Status)
+				currentTasks, err = apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				require.Equal(t, tasks.Successful, currentTasks[0].Status)
+				require.Equal(t, "dealbot 1", currentTasks[0].WorkedBy)
 
-	// update a different task
-	_, status, err = apiClient.UpdateTask(ctx, currentTasks[1].UUID, &client.UpdateTaskRequest{
-		WorkedBy: "dealbot 2",
-		Status:   tasks.Successful,
-	})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, status)
-	currentTasks, err = apiClient.ListTasks(ctx)
-	require.NoError(t, err)
-	require.Equal(t, tasks.Successful, currentTasks[1].Status)
-	require.Equal(t, "dealbot 2", currentTasks[1].WorkedBy)
+				// update a different task
+				task, err = apiClient.UpdateTask(ctx, currentTasks[1].UUID, &client.UpdateTaskRequest{
+					WorkedBy: "dealbot 2",
+					Status:   tasks.Successful,
+				})
+				require.NoError(t, err)
+				require.Equal(t, tasks.Successful, task.Status)
+				currentTasks, err = apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				require.Equal(t, tasks.Successful, currentTasks[1].Status)
+				require.Equal(t, "dealbot 2", currentTasks[1].WorkedBy)
+			},
+			checkMetrics: func(t *testing.T, currentTasks []*tasks.Task, recorder *testrecorder.TestMetricsRecorder) {
+				recorder.AssertExactObservedStatuses(t, currentTasks[0].UUID, tasks.InProgress, tasks.Successful)
+				recorder.AssertExactObservedStatuses(t, currentTasks[1].UUID, tasks.Successful)
+			},
+		},
+		"creating tasks": {
+			runRequests: func(ctx context.Context, t *testing.T, apiClient *client.Client) {
+				newStorageTask := &tasks.StorageTask{
+					Miner:           "t01000",
+					MaxPriceAttoFIL: 100000000000000000, // 0.10 FIL
+					Size:            2048,               // 1kb
+					StartOffset:     0,
+					FastRetrieval:   true,
+					Verified:        true,
+				}
+				task, err := apiClient.CreateStorageTask(ctx, newStorageTask)
+				require.NoError(t, err)
+				require.Equal(t, task.StorageTask, newStorageTask)
+				task, err = apiClient.GetTask(ctx, task.UUID)
+				require.NoError(t, err)
+				require.Equal(t, task.StorageTask, newStorageTask)
+				currentTasks, err := apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				require.Len(t, currentTasks, 5)
 
-	err = c.Shutdown(ctx)
-	require.NoError(t, err)
-	select {
-	case <-ctx.Done():
-		t.Fatalf("no return from serve call")
-	case err = <-serveErr:
-		require.EqualError(t, err, http.ErrServerClosed.Error())
+				newRetrievalTask := &tasks.RetrievalTask{
+					Miner:      "f0127896",
+					PayloadCID: "bafykbzacedikkmeotawrxqquthryw3cijaonobygdp7fb5bujhuos6wdkwomm",
+					CARExport:  false,
+				}
+				task, err = apiClient.CreateRetrievalTask(ctx, newRetrievalTask)
+				require.NoError(t, err)
+				require.Equal(t, task.RetrievalTask, newRetrievalTask)
+				task, err = apiClient.GetTask(ctx, task.UUID)
+				require.NoError(t, err)
+				require.Equal(t, task.RetrievalTask, newRetrievalTask)
+				currentTasks, err = apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				require.Len(t, currentTasks, 6)
+			},
+		},
 	}
 
-	recorder.AssertExactObservedStatuses(t, currentTasks[0].UUID, tasks.InProgress, tasks.Successful)
-	recorder.AssertExactObservedStatuses(t, currentTasks[1].UUID, tasks.Successful)
+	for testCase, data := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+			h := newHarness(t, ctx)
+			if data.runRequests != nil {
+				data.runRequests(ctx, t, h.apiClient)
+			}
+			if data.checkMetrics != nil {
+				finalTasks, err := h.apiClient.ListTasks(ctx)
+				require.NoError(t, err)
+				data.checkMetrics(t, finalTasks, h.recorder)
+			}
+			h.Shutdown(t)
+		})
+	}
+}
+
+type harness struct {
+	ctx        context.Context
+	apiClient  *client.Client
+	recorder   *testrecorder.TestMetricsRecorder
+	controller *controller.Controller
+	serveErr   chan error
+}
+
+func newHarness(t *testing.T, ctx context.Context) *harness {
+	h := &harness{ctx: ctx}
+	h.apiClient = client.NewFromEndpoint("http://localhost:3333")
+	h.recorder = testrecorder.NewTestMetricsRecorder()
+	listener, err := net.Listen("tcp", "localhost:3333")
+	require.NoError(t, err)
+	h.controller = controller.NewWithDependencies(listener, h.recorder)
+	h.serveErr = make(chan error, 1)
+	go func() {
+		err := h.controller.Serve()
+		select {
+		case <-ctx.Done():
+		case h.serveErr <- err:
+		}
+	}()
+	return h
+}
+
+func (h *harness) Shutdown(t *testing.T) {
+	err := h.controller.Shutdown(h.ctx)
+	require.NoError(t, err)
+	select {
+	case <-h.ctx.Done():
+		t.Fatalf("no return from serve call")
+	case err = <-h.serveErr:
+		require.EqualError(t, err, http.ErrServerClosed.Error())
+	}
 }

--- a/controller/state.go
+++ b/controller/state.go
@@ -24,12 +24,12 @@ func (s *state) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.tasks)
 }
 
-func (s *state) Update(req *client.UpdateTaskRequest, recorder metrics.MetricsRecorder) error {
+func (s *state) Update(UUID string, req *client.UpdateTaskRequest, recorder metrics.MetricsRecorder) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	for _, t := range s.tasks {
-		if t.UUID == req.UUID {
+		if t.UUID == UUID {
 			if t.Status == tasks.Available {
 				t.WorkedBy = req.WorkedBy
 				t.StartedAt = time.Now()
@@ -48,7 +48,7 @@ func (s *state) Update(req *client.UpdateTaskRequest, recorder metrics.MetricsRe
 		}
 	}
 
-	return fmt.Errorf("cannot find task with uuid: %s", req.UUID)
+	return fmt.Errorf("cannot find task with uuid: %s", UUID)
 }
 
 func init() {

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/filecoin-project/dealbot/controller/client"
+	"github.com/filecoin-project/dealbot/tasks"
 )
 
 func (c *Controller) getTasksHandler(w http.ResponseWriter, r *http.Request) {
@@ -37,12 +38,94 @@ func (c *Controller) updateTaskHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = State.Update(UUID, req, c.metricsRecorder)
+	task, err := State.Update(UUID, req, c.metricsRecorder)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(State)
+	json.NewEncoder(w).Encode(task)
+}
+
+func (c *Controller) newStorageTaskHandler(w http.ResponseWriter, r *http.Request) {
+	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
+
+	logger.Debugw("handle request", "command", "create task")
+	defer logger.Debugw("request handled", "command", "create task")
+
+	w.Header().Set("Content-Type", "application/json")
+	var storageTask *tasks.StorageTask
+	err := json.NewDecoder(r.Body).Decode(&storageTask)
+	if err != nil {
+		log.Errorw("StorageTask json decode", "err", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	task, err := State.NewStorageTask(storageTask)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	taskURL, err := r.URL.Parse("/tasks/" + task.UUID)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	w.Header().Set("Location", taskURL.String())
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(task)
+}
+
+func (c *Controller) newRetrievalTaskHandler(w http.ResponseWriter, r *http.Request) {
+	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
+
+	logger.Debugw("handle request", "command", "create task")
+	defer logger.Debugw("request handled", "command", "create task")
+
+	w.Header().Set("Content-Type", "application/json")
+	var retrievalTask *tasks.RetrievalTask
+	err := json.NewDecoder(r.Body).Decode(&retrievalTask)
+	if err != nil {
+		log.Errorw("StorageTask json decode", "err", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	task, err := State.NewRetrievalTask(retrievalTask)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	taskURL, err := r.URL.Parse("/tasks/" + task.UUID)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	w.Header().Set("Location", taskURL.String())
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(task)
+}
+
+func (c *Controller) getTaskHandler(w http.ResponseWriter, r *http.Request) {
+	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
+
+	logger.Debugw("handle request", "command", "update task")
+	defer logger.Debugw("request handled", "command", "update task")
+
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	UUID := vars["uuid"]
+
+	task, err := State.Get(UUID)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(task)
 }

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/gorilla/mux"
+
 	"github.com/filecoin-project/dealbot/controller/client"
 )
 
@@ -25,7 +27,8 @@ func (c *Controller) updateTaskHandler(w http.ResponseWriter, r *http.Request) {
 	defer logger.Debugw("request handled", "command", "update task")
 
 	w.Header().Set("Content-Type", "application/json")
-
+	vars := mux.Vars(r)
+	UUID := vars["uuid"]
 	var req *client.UpdateTaskRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -34,7 +37,7 @@ func (c *Controller) updateTaskHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = State.Update(req, c.metricsRecorder)
+	err = State.Update(UUID, req, c.metricsRecorder)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -52,6 +52,7 @@ func New(ctx context.Context, cliCtx *cli.Context) (srv *Daemon, err error) {
 	}
 
 	srv.l, err = net.Listen("tcp", cliCtx.String("listen"))
+	fmt.Println(err)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -52,7 +52,6 @@ func New(ctx context.Context, cliCtx *cli.Context) (srv *Daemon, err error) {
 	}
 
 	srv.l, err = net.Listen("tcp", cliCtx.String("listen"))
-	fmt.Println(err)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/filecoin-project/dealbot/controller/client"
@@ -100,13 +99,9 @@ func (e *Engine) worker(n int) {
 			WorkedBy: e.host,
 		}
 
-		_, status, err := e.client.UpdateTask(ctx, task.UUID, req)
+		task, err = e.client.UpdateTask(ctx, task.UUID, req)
 		if err != nil {
 			log.Warnw("update task returned error", "err", err)
-			continue
-		}
-		if status != http.StatusOK {
-			log.Warnw("status is different to 200", "status", status)
 			continue
 		}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -96,12 +96,11 @@ func (e *Engine) worker(n int) {
 		}
 
 		req := &client.UpdateTaskRequest{
-			UUID:     task.UUID,
 			Status:   2,
 			WorkedBy: e.host,
 		}
 
-		_, status, err := e.client.UpdateTask(ctx, req)
+		_, status, err := e.client.UpdateTask(ctx, task.UUID, req)
 		if err != nil {
 			log.Warnw("update task returned error", "err", err)
 			continue


### PR DESCRIPTION
# Goals

Add the ability to add storage and retrieval tasks to the queue for the controller. This is a simple implementation that allows adding a single task, either storage or retrieval. I can make batch endpoints to add multiple storage and retrieval tasks at the same time as well if it is useful.

# Implementation

- I did a bit of rejiggering of the API to make it more closely follow REST rules (apologies, old web programmer here who gets picky about GET/PUT being idempotent :)
- I added a simple add a strorage task and add a retrieval task endpoint. The other task parameters are controlled by the controller so it made sense to put them in two seperate endpoints that just take the specific parameters. If it's important i can make it a combined endpoint
- Add a get task buy UUID endpoint -- seems like this will be important at some point
- Rejigger HTTP tests to add more functionality testing.

Note: This does not actually persist anything -- it's just adding to the currently in memory queue.