### PR TITLE
Make pop-task non-racy

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -76,8 +76,14 @@ func (c *Client) ListTasks(ctx context.Context) ([]*tasks.Task, error) {
 	return res, nil
 }
 
-func (c *Client) PopTask(ctx context.Context) (*tasks.Task, error) {
-	resp, err := c.request(ctx, "GET", "/pop-task", nil)
+func (c *Client) PopTask(ctx context.Context, r *PopTaskRequest) (*tasks.Task, error) {
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.request(ctx, "POST", "/pop-task", &body)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/client/model.go
+++ b/controller/client/model.go
@@ -6,3 +6,7 @@ type UpdateTaskRequest struct {
 	Status   tasks.Status `json:"status"`
 	WorkedBy string       `json:"worked_by,omitempty"` // which dealbot works on that task
 }
+
+type PopTaskRequest struct {
+	WorkedBy string
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/filecoin-project/dealbot/controller/state"
@@ -30,6 +31,7 @@ type Controller struct {
 	doneCh          chan struct{}
 	db              state.State
 	metricsRecorder metrics.MetricsRecorder
+	popTaskLk       sync.Mutex
 }
 
 func New(ctx *cli.Context) (*Controller, error) {
@@ -99,7 +101,7 @@ func NewWithDependencies(listener net.Listener, recorder metrics.MetricsRecorder
 		})
 	})
 
-	r.HandleFunc("/pop-task", srv.popTaskHandler).Methods("GET")
+	r.HandleFunc("/pop-task", srv.popTaskHandler).Methods("POST")
 	r.HandleFunc("/tasks", srv.getTasksHandler).Methods("GET")
 	r.HandleFunc("/tasks/storage", srv.newStorageTaskHandler).Methods("POST")
 	r.HandleFunc("/tasks/retrieval", srv.newRetrievalTaskHandler).Methods("POST")

--- a/controller/http_test.go
+++ b/controller/http_test.go
@@ -84,17 +84,11 @@ func TestControllerHTTPInterface(t *testing.T) {
 			recorder.AssertExactObservedStatuses(t, currentTasks[1].UUID, tasks.Successful)
 		},
 		"pop a task": func(ctx context.Context, t *testing.T, apiClient *client.Client, recorder *testrecorder.TestMetricsRecorder) {
-			task, err := apiClient.PopTask(ctx)
+			task, err := apiClient.PopTask(ctx, &client.PopTaskRequest{WorkedBy: "dealbot 1"})
 			require.NoError(t, err)
-			require.Equal(t, tasks.Available, task.Status)
+			require.Equal(t, tasks.InProgress, task.Status)
 
-			// update a task
-			updatedTask, err := apiClient.UpdateTask(ctx, task.UUID, &client.UpdateTaskRequest{
-				WorkedBy: "dealbot 1",
-				Status:   tasks.InProgress,
-			})
-			require.NoError(t, err)
-			require.Equal(t, tasks.InProgress, updatedTask.Status)
+			// check task updated
 			refetchTask, err := apiClient.GetTask(ctx, task.UUID)
 			require.NoError(t, err)
 			require.Equal(t, tasks.InProgress, refetchTask.Status)
@@ -110,7 +104,7 @@ func TestControllerHTTPInterface(t *testing.T) {
 				})
 				require.NoError(t, err)
 			}
-			noTask, err := apiClient.PopTask(ctx)
+			noTask, err := apiClient.PopTask(ctx, &client.PopTaskRequest{WorkedBy: "dealbot 1"})
 			require.NoError(t, err)
 			require.Nil(t, noTask)
 		},

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -28,23 +28,24 @@ func (c *Controller) getTasksHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Controller) popTaskHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: use a single SQL transaction to remove the need for a mutex here
+	c.popTaskLk.Lock()
+	defer c.popTaskLk.Unlock()
+
 	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
 
 	logger.Debugw("handle request", "command", "pop task")
 	defer logger.Debugw("request handled", "command", "pop task")
 
 	w.Header().Set("Content-Type", "application/json")
+	var req *client.PopTaskRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		log.Errorw("PopTaskRequest json decode", "err", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
-	// TODO: use a single SQL transaction to query the oldest available
-	// task, *and* mark it as in-progress by the worker.
-	// This will make pop-task non-racy, preventing the follow-up PATCH to
-	// update the status to InProgress and the WorkedBy field.
-	// When that happens, pop-task should probably take the dealbot string,
-	// to be used in WorkedBy. So perhaps pop-task should be a POST then.
-	//
-	// For now, to not touch the DB layer, still do a linear search.
-	// We still expect that the client will do another pop-task call if
-	// another daemon wins the race to self-assigning this task.
 	allTasks, err := c.db.GetAll(r.Context())
 	if err != nil {
 		log.Errorw("getTasks failed: backend", "err", err.Error())
@@ -57,7 +58,17 @@ func (c *Controller) popTaskHandler(w http.ResponseWriter, r *http.Request) {
 			firstAvailable = task
 			break
 		}
-
+	}
+	if firstAvailable != nil {
+		firstAvailable, err = c.db.Update(r.Context(), firstAvailable.UUID, &client.UpdateTaskRequest{
+			WorkedBy: req.WorkedBy,
+			Status:   tasks.InProgress,
+		}, c.metricsRecorder)
+		if err != nil {
+			log.Errorw("UpdateTaskRequest db update", "err", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 	}
 	// If none are available, we return a JSON "null".
 	json.NewEncoder(w).Encode(firstAvailable)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -70,7 +70,7 @@ func (e *Engine) worker(n int) {
 
 		// pop a task
 		ctx := context.Background()
-		task, err := e.client.PopTask(ctx)
+		task, err := e.client.PopTask(ctx, &client.PopTaskRequest{WorkedBy: e.host})
 		if err != nil {
 			log.Warnw("pop-task returned error", "err", err)
 			continue
@@ -78,8 +78,8 @@ func (e *Engine) worker(n int) {
 		if task == nil {
 			continue // no task available
 		}
-		if task.Status != tasks.Available {
-			log.Warnw("pop-task returned a non-available task", "err", err)
+		if task.WorkedBy != e.host {
+			log.Warnw("pop-task returned task that is not for this host", "err", err)
 			continue
 		}
 

--- a/testutil/mockbot.go
+++ b/testutil/mockbot.go
@@ -59,7 +59,7 @@ func (md *MockDaemon) worker(n int) {
 
 		// pop a task
 		ctx := context.Background()
-		task, err := md.client.PopTask(ctx)
+		task, err := md.client.PopTask(ctx, &client.PopTaskRequest{WorkedBy: md.host})
 		if err != nil {
 			log.Warnw("pop-task returned error", "err", err)
 			continue
@@ -69,7 +69,7 @@ func (md *MockDaemon) worker(n int) {
 			continue // no task available
 		}
 
-		if task.Status != tasks.Available {
+		if task.WorkedBy != md.host {
 			log.Warnw("pop-task returned a non-available task", "err", err)
 			continue
 		}


### PR DESCRIPTION
# Goals

While we wait for an SQL rearchitect, this PR implements the machinery to make pop-task non-racy and uses a simple mutex for now to protect the database.

# Implementation

- Convert pop-task to POST
- Have it take a WorkedBy in the request body
- Use a mutex to protect Pop-task handler (remove once we have an SQL version)
- Update the task status to InProgress and assign it in the pop task handler