### PR TITLE
Allow CORS on tasks endpoint

### DIFF
--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -10,6 +10,10 @@ import (
 	"github.com/filecoin-project/dealbot/tasks"
 )
 
+func enableCors(w *http.ResponseWriter) {
+	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+}
+
 func (c *Controller) getTasksHandler(w http.ResponseWriter, r *http.Request) {
 	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
 
@@ -17,6 +21,8 @@ func (c *Controller) getTasksHandler(w http.ResponseWriter, r *http.Request) {
 	defer logger.Debugw("request handled", "command", "list tasks")
 
 	w.Header().Set("Content-Type", "application/json")
+
+	enableCors(&w)
 
 	tasks, err := c.db.GetAll(r.Context())
 	if err != nil {

--- a/testutil/mocktasks.go
+++ b/testutil/mocktasks.go
@@ -47,7 +47,7 @@ func GenerateMockTasks(ctx context.Context, cliCtx *cli.Context) error {
 }
 
 func generateRandomMiner() string {
-	minerNumer := rand.Intn(40000)
+	minerNumer := rand.Intn(10)
 	return fmt.Sprintf("f%d", minerNumer)
 }
 


### PR DESCRIPTION
# Goals

Enable CORS on task endpoint so data loads in Observable

# For Discussion

Should we limit the origin to something less than '*' -- I'm not so worried cause this is just a random get endpoint.

We will probably need to also add PREFETCH when we add basic auth.