### PR TITLE
Do not use separate struct for Task signature

### DIFF
--- a/controller/state/interface.go
+++ b/controller/state/interface.go
@@ -9,10 +9,10 @@ import (
 
 // State provides an interface for presistence.
 type State interface {
-	AssignTask(ctx context.Context, req client.UpdateTaskRequest) (*tasks.AuthenticatedTask, error)
-	Get(ctx context.Context, uuid string) (*tasks.AuthenticatedTask, error)
-	GetAll(ctx context.Context) ([]*tasks.AuthenticatedTask, error)
-	Update(ctx context.Context, uuid string, req client.UpdateTaskRequest) (*tasks.AuthenticatedTask, error)
-	NewStorageTask(ctx context.Context, storageTask *tasks.StorageTask) (*tasks.AuthenticatedTask, error)
-	NewRetrievalTask(ctx context.Context, retrievalTask *tasks.RetrievalTask) (*tasks.AuthenticatedTask, error)
+	AssignTask(ctx context.Context, req client.UpdateTaskRequest) (*tasks.Task, error)
+	Get(ctx context.Context, uuid string) (*tasks.Task, error)
+	GetAll(ctx context.Context) ([]*tasks.Task, error)
+	Update(ctx context.Context, uuid string, req client.UpdateTaskRequest) (*tasks.Task, error)
+	NewStorageTask(ctx context.Context, storageTask *tasks.StorageTask) (*tasks.Task, error)
+	NewRetrievalTask(ctx context.Context, retrievalTask *tasks.RetrievalTask) (*tasks.Task, error)
 }

--- a/controller/state/statedb_test.go
+++ b/controller/state/statedb_test.go
@@ -41,17 +41,14 @@ func TestLoadTask(t *testing.T) {
 		t.Fatalf("expected 0 tasks, got %d", count)
 	}
 
-	err = state.saveTask(ctx, &tasks.AuthenticatedTask{
-		Task: tasks.Task{
-			UUID:   uuid.New().String()[:8],
-			Status: tasks.Available,
-			RetrievalTask: &tasks.RetrievalTask{
-				Miner:      "t01000",
-				PayloadCID: "bafk2bzacedli6qxp43sf54feczjd26jgeyfxv4ucwylujd3xo5s6cohcqbg36",
-				CARExport:  false,
-			},
+	err = state.saveTask(ctx, &tasks.Task{
+		UUID:   uuid.New().String()[:8],
+		Status: tasks.Available,
+		RetrievalTask: &tasks.RetrievalTask{
+			Miner:      "t01000",
+			PayloadCID: "bafk2bzacedli6qxp43sf54feczjd26jgeyfxv4ucwylujd3xo5s6cohcqbg36",
+			CARExport:  false,
 		},
-		Signature: []byte{},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -91,17 +88,14 @@ func TestAssignTask(t *testing.T) {
 		t.Fatal("returned wrong type")
 	}
 
-	task := &tasks.AuthenticatedTask{
-		Task: tasks.Task{
-			UUID:   uuid.New().String()[:8],
-			Status: tasks.Available,
-			RetrievalTask: &tasks.RetrievalTask{
-				Miner:      "t01000",
-				PayloadCID: "bafk2bzacedli6qxp43sf54feczjd26jgeyfxv4ucwylujd3xo5s6cohcqbg36",
-				CARExport:  false,
-			},
+	task := &tasks.Task{
+		UUID:   uuid.New().String()[:8],
+		Status: tasks.Available,
+		RetrievalTask: &tasks.RetrievalTask{
+			Miner:      "t01000",
+			PayloadCID: "bafk2bzacedli6qxp43sf54feczjd26jgeyfxv4ucwylujd3xo5s6cohcqbg36",
+			CARExport:  false,
 		},
-		Signature: []byte{},
 	}
 	err = state.saveTask(ctx, task)
 	if err != nil {
@@ -195,7 +189,7 @@ func TestAssignConcurrentTask(t *testing.T) {
 	}
 
 	release := make(chan struct{})
-	assigned := make([]*tasks.AuthenticatedTask, taskCount)
+	assigned := make([]*tasks.Task, taskCount)
 	errChan := make(chan error)
 	for i := 0; i < taskCount; i++ {
 		go func(n int) {

--- a/metrics/interface.go
+++ b/metrics/interface.go
@@ -9,5 +9,5 @@ import (
 // MetricsRecorder abstracts the process of recording metrics for tasks
 type MetricsRecorder interface {
 	Handler() http.Handler
-	ObserveTask(*tasks.AuthenticatedTask) error
+	ObserveTask(*tasks.Task) error
 }

--- a/metrics/log/log.go
+++ b/metrics/log/log.go
@@ -23,7 +23,7 @@ func (lr *logRecorder) Handler() http.Handler {
 	return nil
 }
 
-func (lr *logRecorder) ObserveTask(task *tasks.AuthenticatedTask) error {
+func (lr *logRecorder) ObserveTask(task *tasks.Task) error {
 	duration := time.Since(task.StartedAt).Milliseconds()
 
 	if task.RetrievalTask != nil {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -72,7 +72,7 @@ func (pmr *prometheusMetricsRecorder) Handler() http.Handler {
 	return promhttp.Handler()
 }
 
-func (pmr *prometheusMetricsRecorder) ObserveTask(task *tasks.AuthenticatedTask) error {
+func (pmr *prometheusMetricsRecorder) ObserveTask(task *tasks.Task) error {
 
 	if task.RetrievalTask != nil {
 		return pmr.observeRetrievalTask(task)
@@ -83,7 +83,7 @@ func (pmr *prometheusMetricsRecorder) ObserveTask(task *tasks.AuthenticatedTask)
 	return fmt.Errorf("Cannot observe task: %s, both tasks are nil", task.UUID)
 }
 
-func (pmr *prometheusMetricsRecorder) observeStorageTask(task *tasks.AuthenticatedTask) error {
+func (pmr *prometheusMetricsRecorder) observeStorageTask(task *tasks.Task) error {
 	observer, err := pmr.storageVec.GetMetricWith(prometheus.Labels{
 		metrics.UUID:            task.UUID,
 		metrics.Miner:           task.StorageTask.Miner,
@@ -101,7 +101,7 @@ func (pmr *prometheusMetricsRecorder) observeStorageTask(task *tasks.Authenticat
 	return nil
 }
 
-func (pmr *prometheusMetricsRecorder) observeRetrievalTask(task *tasks.AuthenticatedTask) error {
+func (pmr *prometheusMetricsRecorder) observeRetrievalTask(task *tasks.Task) error {
 	observer, err := pmr.retrievalVec.GetMetricWith(prometheus.Labels{
 		metrics.UUID:       task.UUID,
 		metrics.Miner:      task.RetrievalTask.Miner,

--- a/metrics/testrecorder/testrecorder.go
+++ b/metrics/testrecorder/testrecorder.go
@@ -24,7 +24,7 @@ func (tr *TestMetricsRecorder) Handler() http.Handler {
 	return nil
 }
 
-func (tr *TestMetricsRecorder) ObserveTask(task *tasks.AuthenticatedTask) error {
+func (tr *TestMetricsRecorder) ObserveTask(task *tasks.Task) error {
 	tr.tasks[task.UUID] = append(tr.tasks[task.UUID], task.Status)
 	return nil
 }

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -1,7 +1,9 @@
 package tasks
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/filecoin-project/go-address"
@@ -24,6 +26,8 @@ type Task struct {
 	StartedAt     time.Time      `json:"started_at,omitempty"` // the time the task was assigned first assigned to the dealbot
 	RetrievalTask *RetrievalTask `json:"retrieval_task,omitempty"`
 	StorageTask   *StorageTask   `json:"storage_task,omitempty"`
+	Signature     []byte         `json:"signature,omitempty"` // signature of Task with this field set to nil
+
 }
 
 type TaskEvent struct {
@@ -39,15 +43,24 @@ func (t Task) Bytes() []byte {
 	return b
 }
 
-type AuthenticatedTask struct {
-	Task
-	Signature []byte
-}
-
-func (t *AuthenticatedTask) Sign(privKey crypto.PrivKey) error {
+func (t *Task) Sign(privKey crypto.PrivKey) error {
 	var err error
+	t.Signature = nil
 	t.Signature, err = privKey.Sign(t.Bytes())
 	return err
+}
+
+func (t *Task) VerifySignature(privKey crypto.PrivKey) error {
+	toCheck := t.Signature
+	refSig, err := privKey.Sign(t.Bytes())
+	if err != nil {
+		return err
+	}
+	t.Signature = toCheck
+	if !bytes.Equal(toCheck, refSig) {
+		return errors.New("signraute mismatch")
+	}
+	return nil
 }
 
 func (t *Task) Log(log *logging.ZapEventLogger) {

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -58,7 +58,7 @@ func (t *Task) VerifySignature(privKey crypto.PrivKey) error {
 	}
 	t.Signature = toCheck
 	if !bytes.Equal(toCheck, refSig) {
-		return errors.New("signraute mismatch")
+		return errors.New("signature mismatch")
 	}
 	return nil
 }


### PR DESCRIPTION
There was no code that needed these separated, so this simplifies the data structure.

- Added Task.VerifySignature()