### PR TITLE
Setup CORS For basic auth

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -108,6 +108,7 @@ func NewWithDependencies(listener net.Listener, recorder metrics.MetricsRecorder
 	r.HandleFunc("/status", srv.reportStatusHandler).Methods("POST")
 	r.HandleFunc("/tasks/{uuid}", srv.updateTaskHandler).Methods("PATCH")
 	r.HandleFunc("/tasks/{uuid}", srv.getTaskHandler).Methods("GET")
+	r.Methods("OPTIONS").HandlerFunc(srv.sendCORSHeaders)
 	metricsHandler := recorder.Handler()
 	if metricsHandler != nil {
 		r.Handle("/metrics", metricsHandler)

--- a/controller/state/statedb_sql.go
+++ b/controller/state/statedb_sql.go
@@ -15,12 +15,12 @@ const (
 		CREATE TABLE IF NOT EXISTS task_status_ledger (
 			uuid varchar(36) NOT NULL,
 			status int,
-			stage string,
+			stage varchar(255) NOT NULL,
 			ts timestamp NOT NULL,
-			PRIMARY KEY(uuid, ts)
+			PRIMARY KEY(uuid, ts),
 			CONSTRAINT fk_status_ledger_uuid FOREIGN KEY (uuid) REFERENCES tasks
 		);
-		CREATE UNIQUE INDEX idx_task_status_ledger_by_stage ON task_status_ledger (uuid, status, stage);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_task_status_ledger_by_stage ON task_status_ledger (uuid, status, stage);
 	`
 
 	assignTaskSQL = `

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -12,8 +12,13 @@ import (
 	"github.com/filecoin-project/dealbot/tasks"
 )
 
-func enableCors(w *http.ResponseWriter) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+func enableCors(w *http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		origin = "*"
+	}
+	(*w).Header().Set("Access-Control-Allow-Origin", origin)
+	(*w).Header().Set("Access-Control-Allow-Headers", "Authorization")
 }
 
 func (c *Controller) getTasksHandler(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +29,7 @@ func (c *Controller) getTasksHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	enableCors(&w)
+	enableCors(&w, r)
 
 	tasks, err := c.db.GetAll(r.Context())
 	if err != nil {
@@ -183,4 +188,9 @@ func (c *Controller) getTaskHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(task)
+}
+
+func (c *Controller) sendCORSHeaders(w http.ResponseWriter, r *http.Request) {
+	enableCors(&w, r)
+	w.WriteHeader(http.StatusOK)
 }

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - "8764:8764"
     depends_on: 
       - db
+    environment: 
+      - VIRTUAL_HOST=localhost
   mockbot:
     build: ..
     command: ["mock", "--endpoint", "http://controller:8764"]
@@ -34,3 +36,11 @@ services:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
     depends_on: 
       - controller
+  nginx-proxy:
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - "./htpasswd:/etc/nginx/htpasswd"
+      - "./vhost:/etc/nginx/vhost.d"

--- a/integration_tests/htpasswd/localhost-no-options
+++ b/integration_tests/htpasswd/localhost-no-options
@@ -1,0 +1,1 @@
+dealbot:$apr1$1sg1dh5n$bPXhILhAAbwSjsk1VdA5q/

--- a/integration_tests/vhost/localhost_location
+++ b/integration_tests/vhost/localhost_location
@@ -1,0 +1,4 @@
+  limit_except OPTIONS {
+		auth_basic	"Restricted localhost";
+		auth_basic_user_file	"/etc/nginx/htpasswd/localhost-no-options";
+  }


### PR DESCRIPTION
# Goals

Allow basic autho on controller endpoints from dashboard observable

# Implementation

- Setup cors responses to OPTIONS request
- Found some issues with the SQL setup code
- Add reverse proxy to docker to simulate basic auth - not there is some unusual configuration we'll need to support on the server
- Verified I was able to make a basic auth request from Observable against the docker setup