### PR TITLE
Support multiple concurrent workers

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -110,6 +110,12 @@ var DaemonFlags = append(DealFlags, append(CommonFlags, append(EndpointFlags, []
 		Aliases: []string{"l"},
 		EnvVars: []string{"DEALBOT_LISTEN"},
 	}),
+	altsrc.NewIntFlag(&cli.IntFlag{
+		Name:    "workers",
+		Usage:   "number of concurrent task workers",
+		EnvVars: []string{"DEALBOT_WORKERS"},
+		Value:   1,
+	}),
 }...)...)...)
 
 var MockFlags = []cli.Flag{

--- a/controller/state/statedb.go
+++ b/controller/state/statedb.go
@@ -330,11 +330,7 @@ func (s *stateDB) Update(ctx context.Context, taskID string, req tasks.UpdateTas
 
 		// publish a task event update as neccesary
 		if (req.Stage.Exists() && req.Stage.Must().String() != task.Stage.String()) || (req.Status.Int() != task.Status.Int()) {
-			lastUpdated := time.Now()
-			if req.CurrentStageDetails.Exists() && req.CurrentStageDetails.Must().UpdatedAt.Exists() {
-				lastUpdated = req.CurrentStageDetails.Must().UpdatedAt.Must().Time()
-			}
-			_, err = tx.ExecContext(ctx, upsertTaskStatusSQL, taskID, updatedTask.Status.Int(), updatedTask.Stage.String(), lastUpdated)
+			_, err = tx.ExecContext(ctx, upsertTaskStatusSQL, taskID, updatedTask.Status.Int(), updatedTask.Stage.String(), time.Now())
 			if err != nil {
 				return err
 			}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -114,7 +114,7 @@ func (e *Engine) worker(ctx context.Context, n int) {
 			continue
 		}
 
-		log.Infow("worker", n, "successfully acquired task", "uuid", task.UUID)
+		log.Infow("successfully acquired task", "uuid", task.UUID, "worker_id", n)
 		e.runTask(ctx, task)
 	}
 }
@@ -146,29 +146,29 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task) {
 		if err != nil {
 			if err == context.Canceled {
 				// Engine closed, do not update final state
-				log.Warn("task", task.UUID.String(), "canceled for shutdown")
+				log.Warn("task canceled for shutdown", "uuid", task.UUID)
 				return
 			}
 			finalStatus = tasks.Failed
-			log.Errorw("retrieval task returned error", "err", err)
+			log.Errorw("retrieval task returned error", "err", err, "uuid", task.UUID)
 		} else {
-			log.Info("successfully retrieved data")
+			log.Info("successfully retrieved data", "uuid", task.UUID)
 		}
 	} else if task.StorageTask.Exists() {
 		err = tasks.MakeStorageDeal(taskCtx, e.nodeConfig, e.node, task.StorageTask.Must(), updateStage, log.Infow)
 		if err != nil {
 			if err == context.Canceled {
 				// Engine closed, do not update final state
-				log.Warn("task", task.UUID.String(), "canceled for shutdown")
+				log.Warn("task canceled for shutdown", "uuid", task.UUID)
 				return
 			}
 			finalStatus = tasks.Failed
-			log.Errorw("storage task returned error", "err", err)
+			log.Errorw("storage task returned error", "err", err, "uuid", task.UUID)
 		} else {
-			log.Info("successfully stored data")
+			log.Info("successfully stored data", "uuid", task.UUID)
 		}
 	} else {
-		log.Error("task", task.UUID.String(), "has unknown deal type")
+		log.Error("task has unknown deal type", "uuid", task.UUID)
 		return
 	}
 
@@ -183,9 +183,9 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task) {
 
 	if err != nil {
 		if err == context.Canceled {
-			log.Warn("task", task.UUID.String(), "canceled for shutdown")
+			log.Warn("task canceled for shutdown", "uuid", task.UUID)
 			return
 		}
-		log.Error("Error updating final status")
+		log.Error("error updating final status", "uuid", task.UUID)
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/filecoin-project/dealbot/controller/client"
@@ -14,6 +15,14 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
+const (
+	nextTaskTimeout = 10 * time.Second
+	noTasksWait     = 5 * time.Second
+	maxTaskLifetime = 24 * time.Hour
+
+	defaultWorkers = 1
+)
+
 var log = logging.Logger("engine")
 
 type Engine struct {
@@ -23,10 +32,16 @@ type Engine struct {
 	nodeConfig tasks.NodeConfig
 	node       api.FullNode
 	closer     lotus.NodeCloser
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 }
 
 func New(ctx context.Context, cliCtx *cli.Context) (*Engine, error) {
-	workers := 1
+	workers := cliCtx.Int("workers")
+	if workers == 0 {
+		workers = defaultWorkers
+	}
 
 	client := client.New(cliCtx)
 
@@ -50,82 +65,140 @@ func New(ctx context.Context, cliCtx *cli.Context) (*Engine, error) {
 		host:       uuid.New().String()[:8], // TODO: set from config toml
 	}
 
+	ctx, e.cancel = context.WithCancel(ctx)
+
+	e.wg.Add(workers)
 	for i := 0; i < workers; i++ {
-		go e.worker(i)
+		go e.worker(ctx, i)
 	}
 
 	return e, nil
 }
 
 func (e *Engine) Close() {
+	e.cancel()  // stop workers
+	e.wg.Wait() // wait for workers to stop
 	e.closer()
 }
 
-func (e *Engine) worker(n int) {
-	log.Infow("engine worker started", "worker_id", n)
+func (e *Engine) popTask(ctx context.Context) tasks.Task {
+	ctx, cancel := context.WithTimeout(ctx, nextTaskTimeout)
+	defer cancel()
 
+	// Pop tasks until a task is found or until no more tasks
 	for {
-		// add delay to avoid querying the controller many times if there are no available tasks
-		time.Sleep(5 * time.Second)
-
+		if ctx.Err() != nil {
+			return nil // no task found before deadline
+		}
 		// pop a task
-		ctx := context.Background()
 		task, err := e.client.PopTask(ctx, tasks.Type.PopTask.Of(e.host, tasks.InProgress))
 		if err != nil {
+			if err == context.DeadlineExceeded {
+				return nil // no task found before deadline
+			}
 			log.Warnw("pop-task returned error", "err", err)
 			continue
 		}
 		if task == nil {
-			continue // no task available
+			return nil // no task available
 		}
 		if task.WorkedBy.Must().String() != e.host {
 			log.Warnw("pop-task returned task that is not for this host", "err", err)
 			continue
 		}
+		return task // found a runable task
+	}
+}
+
+func (e *Engine) worker(ctx context.Context, n int) {
+	defer e.wg.Done()
+
+	log.Infow("engine worker started", "worker_id", n)
+
+	var taskCtx context.Context
+	var taskCancel context.CancelFunc
+	for {
+		// Check if there is a new tasks.
+		task := e.popTask(ctx)
+		if task == nil {
+			// No tasks to run, so wait
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(noTasksWait):
+				continue
+			}
+		}
 
 		log.Infow("successfully acquired task", "uuid", task.UUID)
 
-		finalStatus := tasks.Successful
-		updateStage := func(stage string, stageDetails tasks.StageDetails) error {
-			task, err = e.client.UpdateTask(ctx, task.UUID.String(),
-				tasks.Type.UpdateTask.OfStage(
-					e.host,
-					tasks.InProgress,
-					stage,
-					stageDetails,
-				))
-			return err
-		}
-		if task.RetrievalTask.Exists() {
-			ctx := context.TODO()
-			err = tasks.MakeRetrievalDeal(ctx, e.nodeConfig, e.node, task.RetrievalTask.Must(), updateStage, log.Infow)
-			if err != nil {
-				finalStatus = tasks.Failed
-				log.Errorw("retrieval task returned error", "err", err)
-			} else {
-				log.Info("successfully retrieved data")
-			}
-		}
+		// Create a context to manage the lifetime of the current task
+		taskCtx, taskCancel = context.WithTimeout(ctx, maxTaskLifetime)
 
-		if task.StorageTask.Exists() {
-			ctx := context.TODO()
-			err = tasks.MakeStorageDeal(ctx, e.nodeConfig, e.node, task.StorageTask.Must(), updateStage, log.Infow)
-			if err != nil {
-				finalStatus = tasks.Failed
-				log.Errorw("storage task returned error", "err", err)
-			} else {
-				log.Info("successfully stored data")
-			}
-		}
-		_, err = e.client.UpdateTask(ctx, task.UUID.String(),
+		e.runTask(taskCtx, task)
+		taskCancel()
+	}
+}
+
+func (e *Engine) runTask(ctx context.Context, task tasks.Task) {
+	var err error
+
+	// Define function to update task stage
+	// TODO: updateState func should task context, passed in by deal executor.
+	updateStage := func(stage string, stageDetails tasks.StageDetails) error {
+		task, err = e.client.UpdateTask(ctx, task.UUID.String(),
 			tasks.Type.UpdateTask.OfStage(
 				e.host,
-				finalStatus,
-				task.Stage.String(),
-				task.CurrentStageDetails.Must(),
+				tasks.InProgress,
+				stage,
+				stageDetails,
 			))
+		return err
+	}
+
+	finalStatus := tasks.Successful
+
+	// Start deals
+	if task.RetrievalTask.Exists() {
+		err = tasks.MakeRetrievalDeal(ctx, e.nodeConfig, e.node, task.RetrievalTask.Must(), updateStage, log.Infow)
 		if err != nil {
-			log.Error("Error updating final status")
+			if err == context.Canceled {
+				log.Warn("task", task.UUID.String(), "canceled")
+				return
+			}
+			finalStatus = tasks.Failed
+			log.Errorw("retrieval task returned error", "err", err)
+		} else {
+			log.Info("successfully retrieved data")
 		}
+	}
+	if task.StorageTask.Exists() {
+		err = tasks.MakeStorageDeal(ctx, e.nodeConfig, e.node, task.StorageTask.Must(), updateStage, log.Infow)
+		if err != nil {
+			if err == context.Canceled {
+				log.Warn("task", task.UUID.String(), "canceled")
+				return
+			}
+			finalStatus = tasks.Failed
+			log.Errorw("storage task returned error", "err", err)
+		} else {
+			log.Info("successfully stored data")
+		}
+	}
+
+	_, err = e.client.UpdateTask(ctx, task.UUID.String(),
+		tasks.Type.UpdateTask.OfStage(
+			e.host,
+			finalStatus,
+			task.Stage.String(),
+			task.CurrentStageDetails.Must(),
+		))
+
+	if err != nil {
+		if err == context.Canceled {
+			log.Warn("task", task.UUID.String(), "canceled")
+			return
+		}
+		log.Error("Error updating final status")
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -148,7 +148,7 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task) {
 		if err != nil {
 			if err == context.Canceled {
 				// Engine closed, do not update final state
-				tlog.Warn("task canceled for shutdown")
+				tlog.Warn("task abandoned for shutdown")
 				return
 			}
 			finalStatus = tasks.Failed
@@ -161,7 +161,7 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task) {
 		if err != nil {
 			if err == context.Canceled {
 				// Engine closed, do not update final state
-				tlog.Warn("task canceled for shutdown")
+				tlog.Warn("task abandoned for shutdown")
 				return
 			}
 			finalStatus = tasks.Failed
@@ -185,9 +185,9 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task) {
 
 	if err != nil {
 		if err == context.Canceled {
-			tlog.Warn("task canceled for shutdown")
+			tlog.Warn("task abandoned for shutdown")
 			return
 		}
-		tlog.Error("error updating final status")
+		tlog.Errorw("error updating final status", "err", err)
 	}
 }


### PR DESCRIPTION
- Configurable number of workers, default 1
- Engine.Close() cancels workers
- Each task has its own lifetime timeout