### PR TITLE
Feat/chart 0.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
           release: dealbot-0
           requires:
             - build-push
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
                 \"namespace\": \"<< parameters.namespace >>\",
                 \"release\": \"<< parameters.release >>\",
                 \"chart\": \"filecoin/dealbot\",
-                \"chart_version\": \"0.0.1\",
+                \"chart_version\": \"0.0.2\",
                 \"override_repository\": \"filecoin/dealbot\",
                 \"override_tag\": \"$CIRCLE_SHA1\"
               }}"
@@ -97,7 +97,7 @@ workflows:
           release: dealbot-0
           requires:
             - build-push
-          filters:
-            branches:
-              only:
-                - main
+          # filters:
+          #   branches:
+          #     only:
+          #       - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
                 \"namespace\": \"<< parameters.namespace >>\",
                 \"release\": \"<< parameters.release >>\",
                 \"chart\": \"filecoin/dealbot\",
-                \"chart_version\": \"0.0.2\",
+                \"chart_version\": \"0.0.3\",
                 \"override_repository\": \"filecoin/dealbot\",
                 \"override_tag\": \"$CIRCLE_SHA1\"
               }}"


### PR DESCRIPTION
I had to make a small change to the chart, but it's now 0.0.3.

Deployed by removing the filter, and you can see that here 

https://app.circleci.com/pipelines/github/filecoin-project/dealbot/181/workflows/1707d96b-9fc2-417b-a9f7-bd6d055d9998
and the lotus-infra CI executing the deploy is here
https://app.circleci.com/pipelines/github/filecoin-project/lotus-infra/275/workflows/80a76d1e-7651-488c-91e3-7090bc6666d4


now, you've got two services exposed.

```
◉ kubectl -n ntwk-nerpanet-dealbot get services dealbot-0-controller -o yaml
...
  ports:
  - name: dealbot
    port: 8764
    protocol: TCP
    targetPort: 8764
  - name: dealbotgraphql                <---------------------------------------
    port: 8763
    protocol: TCP
    targetPort: 8763
  selector:
    app: dealbot-controller
    release: dealbot-0
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}

```