### PR TITLE
add command for draining a worker

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -112,6 +112,7 @@ func NewWithDependencies(listener, graphqlListener net.Listener, recorder metric
 		})
 	})
 
+	r.HandleFunc("/drain/{workedby}", srv.drainHandler).Methods("POST")
 	r.HandleFunc("/pop-task", srv.popTaskHandler).Methods("POST")
 	r.HandleFunc("/tasks", srv.getTasksHandler).Methods("GET")
 	r.HandleFunc("/tasks/storage", srv.newStorageTaskHandler).Methods("POST")

--- a/controller/state/interface.go
+++ b/controller/state/interface.go
@@ -14,4 +14,5 @@ type State interface {
 	Update(ctx context.Context, uuid string, req tasks.UpdateTask) (tasks.Task, error)
 	NewStorageTask(ctx context.Context, storageTask tasks.StorageTask) (tasks.Task, error)
 	NewRetrievalTask(ctx context.Context, retrievalTask tasks.RetrievalTask) (tasks.Task, error)
+	DrainWorker(ctx context.Context, worker string) error
 }

--- a/controller/state/migrations/000003_initialize_schema.down.sql
+++ b/controller/state/migrations/000003_initialize_schema.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS drainedWorkers;
+DROP TABLE IF EXISTS drained_workers;
 
 COMMIT;

--- a/controller/state/migrations/000003_initialize_schema.down.sql
+++ b/controller/state/migrations/000003_initialize_schema.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS drainedWorkers;
+
+COMMIT;

--- a/controller/state/migrations/000003_initialize_schema.up.sql
+++ b/controller/state/migrations/000003_initialize_schema.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+CREATE TABLE drainedWorkers (
+    worked_by text,
+    PRIMARY KEY(worked_by)
+);
+
+COMMIT;

--- a/controller/state/migrations/000003_initialize_schema.up.sql
+++ b/controller/state/migrations/000003_initialize_schema.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TABLE drainedWorkers (
+CREATE TABLE drained_workers (
     worked_by text,
     PRIMARY KEY(worked_by)
 );

--- a/controller/state/statedb_dml.go
+++ b/controller/state/statedb_dml.go
@@ -57,4 +57,12 @@ const (
 	cidArchiveSQL = `
 		INSERT INTO finalizedData (cid, data, created) VALUES($1, $2, $3)
 	`
+
+	drainedAddSQL = `
+		INSERT INTO drainedWorkers (worked_by) VALUES ($1)
+	`
+
+	drainedQuerySQL = `
+		SELECT COUNT(*) as cnt FROM drainedWorkers WHERE worked_by = $1
+	`
 )

--- a/controller/state/statedb_dml.go
+++ b/controller/state/statedb_dml.go
@@ -59,10 +59,10 @@ const (
 	`
 
 	drainedAddSQL = `
-		INSERT INTO drainedWorkers (worked_by) VALUES ($1)
+		INSERT INTO drained_workers (worked_by) VALUES ($1)
 	`
 
 	drainedQuerySQL = `
-		SELECT COUNT(*) as cnt FROM drainedWorkers WHERE worked_by = $1
+		SELECT COUNT(*) as cnt FROM drained_workers WHERE worked_by = $1
 	`
 )


### PR DESCRIPTION
makes a table, with a handler to indicate tasks shouldn't go to a specific bot, and querying on assignments.