### PR TITLE
use 0.0.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
                 \"namespace\": \"<< parameters.namespace >>\",
                 \"release\": \"<< parameters.release >>\",
                 \"chart\": \"filecoin/dealbot\",
-                \"chart_version\": \"0.0.3\",
+                \"chart_version\": \"0.0.4\",
                 \"override_repository\": \"filecoin/dealbot\",
                 \"override_tag\": \"$CIRCLE_SHA1\"
               }}"


### PR DESCRIPTION
0.0.4 moves graphql to its own service so it is exposed directly with external IP