### PR TITLE
add structure for record updates

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -113,6 +113,7 @@ func NewWithDependencies(listener, graphqlListener net.Listener, recorder metric
 	})
 
 	r.HandleFunc("/drain/{workedby}", srv.drainHandler).Methods("POST")
+	r.HandleFunc("/complete/{workedby}", srv.completeHandler).Methods("POST")
 	r.HandleFunc("/pop-task", srv.popTaskHandler).Methods("POST")
 	r.HandleFunc("/tasks", srv.getTasksHandler).Methods("GET")
 	r.HandleFunc("/tasks/storage", srv.newStorageTaskHandler).Methods("POST")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -134,15 +134,13 @@ func NewWithDependencies(listener, graphqlListener net.Listener, recorder metric
 	}
 
 	if graphqlListener != nil {
-		gm := mux.NewRouter().StrictSlash(true)
 		gqlHandler, err := graphql.GetHandler(srv.db)
 		if err != nil {
 			return nil, err
 		}
-		gm.Handle("/", gqlHandler)
 
 		srv.gserver = &http.Server{
-			Handler:      handlers.LoggingHandler(os.Stdout, gm),
+			Handler:      handlers.LoggingHandler(os.Stdout, gqlHandler),
 			WriteTimeout: 30 * time.Second,
 			ReadTimeout:  30 * time.Second,
 		}

--- a/controller/graphql/schema.go
+++ b/controller/graphql/schema.go
@@ -36,54 +36,124 @@ func resolve_map_at(p graphql.ResolveParams) (interface{}, error) {
         return nil, fmt.Errorf("unknown key type: %T", arg)
     }
 }
-func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
+func Status__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        i, err := value.AsInt()
+        if err != nil {
+            return err
+        }
+        return i
+        
+    default:
+        return nil
+    }
+}
+func Status__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Status__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Status__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Status__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Status__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Status",
+    Description: "Status",
+    Serialize: Status__type__serialize,
+    ParseValue: Status__type__parse,
+    ParseLiteral: Status__type__parseLiteral,
+})
+func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
     if !ok {
         return nil, errNotNode
     }
     
-    f := ts.FieldDescription()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
+    return ts.FieldMiner().AsString()
     
 }
-func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
+func RetrievalTask__PayloadCID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
     if !ok {
         return nil, errNotNode
     }
     
-    f := ts.FieldExpectedDuration()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
+    return ts.FieldPayloadCID().AsString()
     
 }
-func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
+func RetrievalTask__CARExport__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
     if !ok {
         return nil, errNotNode
     }
     
-    return ts.FieldLogs(), nil
+    return ts.FieldCARExport().AsBool()
     
 }
-func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
+var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "RetrievalTask",
+    Fields: graphql.Fields{
+        "Miner": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: RetrievalTask__Miner__resolve,
+        },
+        "PayloadCID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: RetrievalTask__PayloadCID__resolve,
+        },
+        "CARExport": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: RetrievalTask__CARExport__resolve,
+        },
+    },
+})
+func FinishedTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
     if !ok {
         return nil, errNotNode
     }
     
-    f := ts.FieldUpdatedAt()
+    return ts.FieldStatus(), nil
+    
+}
+func FinishedTask__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStartedAt(), nil
+    
+}
+func FinishedTask__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldRetrievalTask()
     if f.Exists() {
         
         return f.Must(), nil
@@ -93,32 +163,278 @@ func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, err
     }
     
 }
-var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "StageDetails",
+func FinishedTask__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStorageTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func FinishedTask__DealID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldDealID().AsInt()
+    
+}
+func FinishedTask__MinerMultiAddr__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMinerMultiAddr().AsString()
+    
+}
+func FinishedTask__ClientApparentAddr__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldClientApparentAddr().AsString()
+    
+}
+func FinishedTask__MinerLatencyMS__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldMinerLatencyMS()
+    if f.Exists() {
+        
+        return f.Must().AsInt()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func FinishedTask__TimeToFirstByteMS__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldTimeToFirstByteMS()
+    if f.Exists() {
+        
+        return f.Must().AsInt()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func FinishedTask__TimeToLastByteMS__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldTimeToLastByteMS()
+    if f.Exists() {
+        
+        return f.Must().AsInt()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func FinishedTask__Events__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.FinishedTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    targetCid := ts.FieldEvents().Link()
+    
+			var node ipld.Node
+			
+	if cl, ok := targetCid.(cidlink.Link); ok {
+		v := p.Context.Value(nodeLoaderCtxKey)
+		if v == nil {
+			return cl.Cid, nil
+		}
+		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
+		if !ok {
+			return nil, errInvalidLoader
+		}
+
+		builder := tasks.Type.List_StageDetails__Repr.NewBuilder()
+		n, err := loader(p.Context, cl, builder);
+		if err != nil {
+			return nil, err
+		}
+		node = n
+	} else {
+		return nil, errInvalidLink
+	}
+	
+			return node, nil
+			
+    
+}
+var FinishedTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "FinishedTask",
     Fields: graphql.Fields{
-        "Description": &graphql.Field{
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: FinishedTask__Status__resolve,
+        },
+        "StartedAt": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Time__type),
+            
+            Resolve: FinishedTask__StartedAt__resolve,
+        },
+        "RetrievalTask": &graphql.Field{
+            
+            Type: RetrievalTask__type,
+            
+            Resolve: FinishedTask__RetrievalTask__resolve,
+        },
+        "StorageTask": &graphql.Field{
+            
+            Type: StorageTask__type,
+            
+            Resolve: FinishedTask__StorageTask__resolve,
+        },
+        "DealID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: FinishedTask__DealID__resolve,
+        },
+        "MinerMultiAddr": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: FinishedTask__MinerMultiAddr__resolve,
+        },
+        "ClientApparentAddr": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: FinishedTask__ClientApparentAddr__resolve,
+        },
+        "MinerLatencyMS": &graphql.Field{
+            
+            Type: graphql.Int,
+            
+            Resolve: FinishedTask__MinerLatencyMS__resolve,
+        },
+        "TimeToFirstByteMS": &graphql.Field{
+            
+            Type: graphql.Int,
+            
+            Resolve: FinishedTask__TimeToFirstByteMS__resolve,
+        },
+        "TimeToLastByteMS": &graphql.Field{
+            
+            Type: graphql.Int,
+            
+            Resolve: FinishedTask__TimeToLastByteMS__resolve,
+        },
+        "Events": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_StageDetails__type),
+            
+            Resolve: FinishedTask__Events__resolve,
+        },
+    },
+})
+func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStatus(), nil
+    
+}
+func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStage()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldCurrentStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func UpdateTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldWorkedBy().AsString()
+    
+}
+var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "UpdateTask",
+    Fields: graphql.Fields{
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: UpdateTask__Status__resolve,
+        },
+        "Stage": &graphql.Field{
             
             Type: graphql.String,
             
-            Resolve: StageDetails__Description__resolve,
+            Resolve: UpdateTask__Stage__resolve,
         },
-        "ExpectedDuration": &graphql.Field{
+        "CurrentStageDetails": &graphql.Field{
             
-            Type: graphql.String,
+            Type: StageDetails__type,
             
-            Resolve: StageDetails__ExpectedDuration__resolve,
+            Resolve: UpdateTask__CurrentStageDetails__resolve,
         },
-        "Logs": &graphql.Field{
+        "WorkedBy": &graphql.Field{
             
-            Type: graphql.NewNonNull(List_Logs__type),
+            Type: graphql.NewNonNull(graphql.String),
             
-            Resolve: StageDetails__Logs__resolve,
-        },
-        "UpdatedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: StageDetails__UpdatedAt__resolve,
+            Resolve: UpdateTask__WorkedBy__resolve,
         },
     },
 })
@@ -215,8 +531,110 @@ var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })	
-func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
+var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_Logs",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Logs__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldUUID().AsString()
+    
+}
+func Task__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
     if !ok {
         return nil, errNotNode
     }
@@ -224,13 +642,13 @@ func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
     return ts.FieldStatus(), nil
     
 }
-func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
+func Task__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
     if !ok {
         return nil, errNotNode
     }
     
-    f := ts.FieldStage()
+    f := ts.FieldWorkedBy()
     if f.Exists() {
         
         return f.Must().AsString()
@@ -240,8 +658,17 @@ func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
     }
     
 }
-func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
+func Task__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStage().AsString()
+    
+}
+func Task__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
     if !ok {
         return nil, errNotNode
     }
@@ -256,41 +683,809 @@ func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interfac
     }
     
 }
-func UpdateTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
+func Task__PastStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
     if !ok {
         return nil, errNotNode
     }
     
-    return ts.FieldWorkedBy().AsString()
+    f := ts.FieldPastStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
     
 }
-var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "UpdateTask",
+func Task__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStartedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldRetrievalTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStorageTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var Task__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Task",
     Fields: graphql.Fields{
+        "UUID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Task__UUID__resolve,
+        },
         "Status": &graphql.Field{
             
             Type: graphql.NewNonNull(Status__type),
             
-            Resolve: UpdateTask__Status__resolve,
+            Resolve: Task__Status__resolve,
         },
-        "Stage": &graphql.Field{
+        "WorkedBy": &graphql.Field{
             
             Type: graphql.String,
             
-            Resolve: UpdateTask__Stage__resolve,
+            Resolve: Task__WorkedBy__resolve,
+        },
+        "Stage": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Task__Stage__resolve,
         },
         "CurrentStageDetails": &graphql.Field{
             
             Type: StageDetails__type,
             
-            Resolve: UpdateTask__CurrentStageDetails__resolve,
+            Resolve: Task__CurrentStageDetails__resolve,
         },
-        "WorkedBy": &graphql.Field{
+        "PastStageDetails": &graphql.Field{
+            
+            Type: List_StageDetails__type,
+            
+            Resolve: Task__PastStageDetails__resolve,
+        },
+        "StartedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: Task__StartedAt__resolve,
+        },
+        "RetrievalTask": &graphql.Field{
+            
+            Type: RetrievalTask__type,
+            
+            Resolve: Task__RetrievalTask__resolve,
+        },
+        "StorageTask": &graphql.Field{
+            
+            Type: StorageTask__type,
+            
+            Resolve: Task__StorageTask__resolve,
+        },
+    },
+})
+func Time__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        i, err := value.AsInt()
+        if err != nil {
+            return err
+        }
+        return i
+        
+    default:
+        return nil
+    }
+}
+func Time__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Time__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Time__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Time__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Time__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Time",
+    Description: "Time",
+    Serialize: Time__type__serialize,
+    ParseValue: Time__type__parse,
+    ParseLiteral: Time__type__parseLiteral,
+})
+func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldDescription()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldExpectedDuration()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldLogs(), nil
+    
+}
+func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldUpdatedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "StageDetails",
+    Fields: graphql.Fields{
+        "Description": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__Description__resolve,
+        },
+        "ExpectedDuration": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__ExpectedDuration__resolve,
+        },
+        "Logs": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_Logs__type),
+            
+            Resolve: StageDetails__Logs__resolve,
+        },
+        "UpdatedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: StageDetails__UpdatedAt__resolve,
+        },
+    },
+})
+var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_AuthenticatedRecord",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: AuthenticatedRecord__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(AuthenticatedRecord__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(AuthenticatedRecord__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func StorageTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMiner().AsString()
+    
+}
+func StorageTask__MaxPriceAttoFIL__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMaxPriceAttoFIL().AsInt()
+    
+}
+func StorageTask__Size__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSize().AsInt()
+    
+}
+func StorageTask__StartOffset__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStartOffset().AsInt()
+    
+}
+func StorageTask__FastRetrieval__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldFastRetrieval().AsBool()
+    
+}
+func StorageTask__Verified__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldVerified().AsBool()
+    
+}
+var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "StorageTask",
+    Fields: graphql.Fields{
+        "Miner": &graphql.Field{
             
             Type: graphql.NewNonNull(graphql.String),
             
-            Resolve: UpdateTask__WorkedBy__resolve,
+            Resolve: StorageTask__Miner__resolve,
+        },
+        "MaxPriceAttoFIL": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: StorageTask__MaxPriceAttoFIL__resolve,
+        },
+        "Size": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: StorageTask__Size__resolve,
+        },
+        "StartOffset": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: StorageTask__StartOffset__resolve,
+        },
+        "FastRetrieval": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: StorageTask__FastRetrieval__resolve,
+        },
+        "Verified": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: StorageTask__Verified__resolve,
+        },
+    },
+})
+var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Tasks",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Task__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func AuthenticatedRecord__Record__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.AuthenticatedRecord)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    targetCid := ts.FieldRecord().Link()
+    
+			var node ipld.Node
+			
+	if cl, ok := targetCid.(cidlink.Link); ok {
+		v := p.Context.Value(nodeLoaderCtxKey)
+		if v == nil {
+			return cl.Cid, nil
+		}
+		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
+		if !ok {
+			return nil, errInvalidLoader
+		}
+
+		builder := tasks.Type.FinishedTask__Repr.NewBuilder()
+		n, err := loader(p.Context, cl, builder);
+		if err != nil {
+			return nil, err
+		}
+		node = n
+	} else {
+		return nil, errInvalidLink
+	}
+	
+			return node, nil
+			
+    
+}
+func AuthenticatedRecord__Signature__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.AuthenticatedRecord)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSignature(), nil
+    
+}
+var AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "AuthenticatedRecord",
+    Fields: graphql.Fields{
+        "Record": &graphql.Field{
+            
+            Type: graphql.NewNonNull(FinishedTask__type),
+            
+            Resolve: AuthenticatedRecord__Record__resolve,
+        },
+        "Signature": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Bytes__type),
+            
+            Resolve: AuthenticatedRecord__Signature__resolve,
+        },
+    },
+})
+func Bytes__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        b, err := value.AsBytes()
+        if err != nil {
+            return err
+        }
+        return b
+        
+    default:
+        return nil
+    }
+}
+func Bytes__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Bytes__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Bytes__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Bytes__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Bytes",
+    Description: "Bytes",
+    Serialize: Bytes__type__serialize,
+    ParseValue: Bytes__type__parse,
+    ParseLiteral: Bytes__type__parseLiteral,
+})
+func Logs__Log__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Logs)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldLog().AsString()
+    
+}
+func Logs__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Logs)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldUpdatedAt(), nil
+    
+}
+var Logs__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Logs",
+    Fields: graphql.Fields{
+        "Log": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Logs__Log__resolve,
+        },
+        "UpdatedAt": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Time__type),
+            
+            Resolve: Logs__UpdatedAt__resolve,
+        },
+    },
+})
+func RecordUpdate__Records__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldRecords(), nil
+    
+}
+func RecordUpdate__Previous__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldPrevious(), nil
+    
+}
+var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "RecordUpdate",
+    Fields: graphql.Fields{
+        "Records": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_AuthenticatedRecord__type),
+            
+            Resolve: RecordUpdate__Records__resolve,
+        },
+        "Previous": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.ID),
+            
+            Resolve: RecordUpdate__Previous__resolve,
+        },
+    },
+})
+var Map__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Map",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Any__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.String),
+                },
+            },	
+            Resolve: resolve_map_at,
+        },
+        "Keys": &graphql.Field{
+            Type: graphql.NewList(graphql.String),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    node, _, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    children = append(children, node)
+                }
+                return children, nil
+            },
+        },
+        "Values": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Map__type__entry),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([][]ipld.Node, 0)
+
+                for !it.Done() {
+                    k, v, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    children = append(children, []ipld.Node{k, v})
+                }
+                return children, nil
+            },
+        },
+    },	
+})
+var Map__type__entry = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Map_Entry",
+    Fields: graphql.Fields{
+        "Key": &graphql.Field{
+            Type: graphql.String,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                kv, ok := p.Source.([]ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return kv[0], nil
+            },
+        },
+        "Value": &graphql.Field{
+            Type: Any__type,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                kv, ok := p.Source.([]ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return kv[1], nil
+            },
         },
     },
 })
@@ -588,379 +1783,6 @@ var union__Any__Link = graphql.NewObject(graphql.ObjectConfig{
     },
 })
 
-func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMiner().AsString()
-    
-}
-func RetrievalTask__PayloadCID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldPayloadCID().AsString()
-    
-}
-func RetrievalTask__CARExport__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldCARExport().AsBool()
-    
-}
-var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "RetrievalTask",
-    Fields: graphql.Fields{
-        "Miner": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: RetrievalTask__Miner__resolve,
-        },
-        "PayloadCID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: RetrievalTask__PayloadCID__resolve,
-        },
-        "CARExport": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: RetrievalTask__CARExport__resolve,
-        },
-    },
-})
-var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Tasks",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Task__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func Logs__Log__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Logs)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldLog().AsString()
-    
-}
-func Logs__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Logs)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldUpdatedAt(), nil
-    
-}
-var Logs__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Logs",
-    Fields: graphql.Fields{
-        "Log": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Logs__Log__resolve,
-        },
-        "UpdatedAt": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Time__type),
-            
-            Resolve: Logs__UpdatedAt__resolve,
-        },
-    },
-})
-var Map__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Map",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Any__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.String),
-                },
-            },	
-            Resolve: resolve_map_at,
-        },
-        "Keys": &graphql.Field{
-            Type: graphql.NewList(graphql.String),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    node, _, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    children = append(children, node)
-                }
-                return children, nil
-            },
-        },
-        "Values": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Map__type__entry),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([][]ipld.Node, 0)
-
-                for !it.Done() {
-                    k, v, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    children = append(children, []ipld.Node{k, v})
-                }
-                return children, nil
-            },
-        },
-    },	
-})
-var Map__type__entry = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Map_Entry",
-    Fields: graphql.Fields{
-        "Key": &graphql.Field{
-            Type: graphql.String,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                kv, ok := p.Source.([]ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return kv[0], nil
-            },
-        },
-        "Value": &graphql.Field{
-            Type: Any__type,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                kv, ok := p.Source.([]ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return kv[1], nil
-            },
-        },
-    },
-})
-func StorageTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMiner().AsString()
-    
-}
-func StorageTask__MaxPriceAttoFIL__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMaxPriceAttoFIL().AsInt()
-    
-}
-func StorageTask__Size__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldSize().AsInt()
-    
-}
-func StorageTask__StartOffset__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStartOffset().AsInt()
-    
-}
-func StorageTask__FastRetrieval__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldFastRetrieval().AsBool()
-    
-}
-func StorageTask__Verified__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldVerified().AsBool()
-    
-}
-var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "StorageTask",
-    Fields: graphql.Fields{
-        "Miner": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: StorageTask__Miner__resolve,
-        },
-        "MaxPriceAttoFIL": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: StorageTask__MaxPriceAttoFIL__resolve,
-        },
-        "Size": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: StorageTask__Size__resolve,
-        },
-        "StartOffset": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: StorageTask__StartOffset__resolve,
-        },
-        "FastRetrieval": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: StorageTask__FastRetrieval__resolve,
-        },
-        "Verified": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: StorageTask__Verified__resolve,
-        },
-    },
-})
 func PopTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.PopTask)
     if !ok {
@@ -993,640 +1815,6 @@ var PopTask__type = graphql.NewObject(graphql.ObjectConfig{
             Type: graphql.NewNonNull(graphql.String),
             
             Resolve: PopTask__WorkedBy__resolve,
-        },
-    },
-})
-func Bytes__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        b, err := value.AsBytes()
-        if err != nil {
-            return err
-        }
-        return b
-        
-    default:
-        return nil
-    }
-}
-func Bytes__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Bytes__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Bytes__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Bytes__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Bytes",
-    Description: "Bytes",
-    Serialize: Bytes__type__serialize,
-    ParseValue: Bytes__type__parse,
-    ParseLiteral: Bytes__type__parseLiteral,
-})
-func Time__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        i, err := value.AsInt()
-        if err != nil {
-            return err
-        }
-        return i
-        
-    default:
-        return nil
-    }
-}
-func Time__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Time__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Time__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Time__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Time__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Time",
-    Description: "Time",
-    Serialize: Time__type__serialize,
-    ParseValue: Time__type__parse,
-    ParseLiteral: Time__type__parseLiteral,
-})
-func Status__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        i, err := value.AsInt()
-        if err != nil {
-            return err
-        }
-        return i
-        
-    default:
-        return nil
-    }
-}
-func Status__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Status__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Status__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Status__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Status__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Status",
-    Description: "Status",
-    Serialize: Status__type__serialize,
-    ParseValue: Status__type__parse,
-    ParseLiteral: Status__type__parseLiteral,
-})
-var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_Logs",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Logs__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldUUID().AsString()
-    
-}
-func Task__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func Task__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldWorkedBy()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStage().AsString()
-    
-}
-func Task__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldCurrentStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__PastStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldPastStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStartedAt()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldRetrievalTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStorageTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var Task__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Task",
-    Fields: graphql.Fields{
-        "UUID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__UUID__resolve,
-        },
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: Task__Status__resolve,
-        },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: Task__WorkedBy__resolve,
-        },
-        "Stage": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__Stage__resolve,
-        },
-        "CurrentStageDetails": &graphql.Field{
-            
-            Type: StageDetails__type,
-            
-            Resolve: Task__CurrentStageDetails__resolve,
-        },
-        "PastStageDetails": &graphql.Field{
-            
-            Type: List_StageDetails__type,
-            
-            Resolve: Task__PastStageDetails__resolve,
-        },
-        "StartedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: Task__StartedAt__resolve,
-        },
-        "RetrievalTask": &graphql.Field{
-            
-            Type: RetrievalTask__type,
-            
-            Resolve: Task__RetrievalTask__resolve,
-        },
-        "StorageTask": &graphql.Field{
-            
-            Type: StorageTask__type,
-            
-            Resolve: Task__StorageTask__resolve,
-        },
-    },
-})
-func FinishedTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func FinishedTask__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStartedAt(), nil
-    
-}
-func FinishedTask__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldRetrievalTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func FinishedTask__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStorageTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func FinishedTask__DealID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldDealID().AsInt()
-    
-}
-func FinishedTask__MinerMultiAddr__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMinerMultiAddr().AsString()
-    
-}
-func FinishedTask__ClientApparentAddr__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldClientApparentAddr().AsString()
-    
-}
-func FinishedTask__MinerLatencyMS__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldMinerLatencyMS()
-    if f.Exists() {
-        
-        return f.Must().AsInt()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func FinishedTask__TimeToFirstByteMS__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldTimeToFirstByteMS()
-    if f.Exists() {
-        
-        return f.Must().AsInt()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func FinishedTask__TimeToLastByteMS__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldTimeToLastByteMS()
-    if f.Exists() {
-        
-        return f.Must().AsInt()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func FinishedTask__Events__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.FinishedTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    targetCid := ts.FieldEvents().Link()
-    
-			var node ipld.Node
-			
-	if cl, ok := targetCid.(cidlink.Link); ok {
-		v := p.Context.Value(nodeLoaderCtxKey)
-		if v == nil {
-			return cl.Cid, nil
-		}
-		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
-		if !ok {
-			return nil, errInvalidLoader
-		}
-
-		builder := tasks.Type.List_StageDetails__Repr.NewBuilder()
-		n, err := loader(p.Context, cl, builder);
-		if err != nil {
-			return nil, err
-		}
-		node = n
-	} else {
-		return nil, errInvalidLink
-	}
-	
-			return node, nil
-			
-    
-}
-var FinishedTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "FinishedTask",
-    Fields: graphql.Fields{
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: FinishedTask__Status__resolve,
-        },
-        "StartedAt": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Time__type),
-            
-            Resolve: FinishedTask__StartedAt__resolve,
-        },
-        "RetrievalTask": &graphql.Field{
-            
-            Type: RetrievalTask__type,
-            
-            Resolve: FinishedTask__RetrievalTask__resolve,
-        },
-        "StorageTask": &graphql.Field{
-            
-            Type: StorageTask__type,
-            
-            Resolve: FinishedTask__StorageTask__resolve,
-        },
-        "DealID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: FinishedTask__DealID__resolve,
-        },
-        "MinerMultiAddr": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: FinishedTask__MinerMultiAddr__resolve,
-        },
-        "ClientApparentAddr": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: FinishedTask__ClientApparentAddr__resolve,
-        },
-        "MinerLatencyMS": &graphql.Field{
-            
-            Type: graphql.Int,
-            
-            Resolve: FinishedTask__MinerLatencyMS__resolve,
-        },
-        "TimeToFirstByteMS": &graphql.Field{
-            
-            Type: graphql.Int,
-            
-            Resolve: FinishedTask__TimeToFirstByteMS__resolve,
-        },
-        "TimeToLastByteMS": &graphql.Field{
-            
-            Type: graphql.Int,
-            
-            Resolve: FinishedTask__TimeToLastByteMS__resolve,
-        },
-        "Events": &graphql.Field{
-            
-            Type: graphql.NewNonNull(List_StageDetails__type),
-            
-            Resolve: FinishedTask__Events__resolve,
         },
     },
 })

--- a/controller/graphql/schema.go
+++ b/controller/graphql/schema.go
@@ -36,134 +36,6 @@ func resolve_map_at(p graphql.ResolveParams) (interface{}, error) {
         return nil, fmt.Errorf("unknown key type: %T", arg)
     }
 }
-var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_Logs",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Logs__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func PopTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.PopTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func PopTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.PopTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldWorkedBy().AsString()
-    
-}
-var PopTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "PopTask",
-    Fields: graphql.Fields{
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: PopTask__Status__resolve,
-        },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: PopTask__WorkedBy__resolve,
-        },
-    },
-})
 var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
     Name: "List_AuthenticatedRecord",
     Fields: graphql.Fields{
@@ -257,428 +129,6 @@ var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })	
-func Bytes__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        b, err := value.AsBytes()
-        if err != nil {
-            return err
-        }
-        return b
-        
-    default:
-        return nil
-    }
-}
-func Bytes__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Bytes__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Bytes__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Bytes__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Bytes",
-    Description: "Bytes",
-    Serialize: Bytes__type__serialize,
-    ParseValue: Bytes__type__parse,
-    ParseLiteral: Bytes__type__parseLiteral,
-})
-var List__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Any__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func Status__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        i, err := value.AsInt()
-        if err != nil {
-            return err
-        }
-        return i
-        
-    default:
-        return nil
-    }
-}
-func Status__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Status__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Status__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Status__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Status__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Status",
-    Description: "Status",
-    Serialize: Status__type__serialize,
-    ParseValue: Status__type__parse,
-    ParseLiteral: Status__type__parseLiteral,
-})
-var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_StageDetails",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: StageDetails__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(StageDetails__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(StageDetails__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-var Map__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Map",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Any__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.String),
-                },
-            },	
-            Resolve: resolve_map_at,
-        },
-        "Keys": &graphql.Field{
-            Type: graphql.NewList(graphql.String),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    node, _, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    children = append(children, node)
-                }
-                return children, nil
-            },
-        },
-        "Values": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Map__type__entry),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([][]ipld.Node, 0)
-
-                for !it.Done() {
-                    k, v, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    children = append(children, []ipld.Node{k, v})
-                }
-                return children, nil
-            },
-        },
-    },	
-})
-var Map__type__entry = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Map_Entry",
-    Fields: graphql.Fields{
-        "Key": &graphql.Field{
-            Type: graphql.String,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                kv, ok := p.Source.([]ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return kv[0], nil
-            },
-        },
-        "Value": &graphql.Field{
-            Type: Any__type,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                kv, ok := p.Source.([]ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return kv[1], nil
-            },
-        },
-    },
-})
-func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMiner().AsString()
-    
-}
-func RetrievalTask__PayloadCID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldPayloadCID().AsString()
-    
-}
-func RetrievalTask__CARExport__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldCARExport().AsBool()
-    
-}
-var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "RetrievalTask",
-    Fields: graphql.Fields{
-        "Miner": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: RetrievalTask__Miner__resolve,
-        },
-        "PayloadCID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: RetrievalTask__PayloadCID__resolve,
-        },
-        "CARExport": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: RetrievalTask__CARExport__resolve,
-        },
-    },
-})
 func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.Task)
     if !ok {
@@ -861,92 +311,543 @@ var Task__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
-func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldDescription()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldExpectedDuration()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldLogs(), nil
-    
-}
-func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldUpdatedAt()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "StageDetails",
+var Map__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Map",
     Fields: graphql.Fields{
-        "Description": &graphql.Field{
-            
+        "At": &graphql.Field{
+            Type: Any__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.String),
+                },
+            },	
+            Resolve: resolve_map_at,
+        },
+        "Keys": &graphql.Field{
+            Type: graphql.NewList(graphql.String),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    node, _, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    children = append(children, node)
+                }
+                return children, nil
+            },
+        },
+        "Values": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Map__type__entry),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([][]ipld.Node, 0)
+
+                for !it.Done() {
+                    k, v, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    children = append(children, []ipld.Node{k, v})
+                }
+                return children, nil
+            },
+        },
+    },	
+})
+var Map__type__entry = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Map_Entry",
+    Fields: graphql.Fields{
+        "Key": &graphql.Field{
             Type: graphql.String,
-            
-            Resolve: StageDetails__Description__resolve,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                kv, ok := p.Source.([]ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return kv[0], nil
+            },
         },
-        "ExpectedDuration": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: StageDetails__ExpectedDuration__resolve,
-        },
-        "Logs": &graphql.Field{
-            
-            Type: graphql.NewNonNull(List_Logs__type),
-            
-            Resolve: StageDetails__Logs__resolve,
-        },
-        "UpdatedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: StageDetails__UpdatedAt__resolve,
+        "Value": &graphql.Field{
+            Type: Any__type,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                kv, ok := p.Source.([]ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return kv[1], nil
+            },
         },
     },
 })
+var Any__type = graphql.NewUnion(graphql.UnionConfig{
+    Name: "Any",
+    Types: []*graphql.Object{
+        
+        union__Any__Bool,
+        
+        
+        union__Any__Int,
+        
+        
+        union__Any__Float,
+        
+        
+        union__Any__String,
+        
+        
+        union__Any__Bytes,
+        
+        
+        union__Any__Map,
+        
+        
+        union__Any__List,
+        
+        
+        union__Any__Link,
+        
+    },
+    ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+        if node, ok := p.Value.(ipld.Node); ok {
+            switch node.Prototype() {
+            
+            case tasks.Type.Bool:
+                fallthrough
+            case tasks.Type.Bool__Repr:
+                return union__Any__Bool
+            
+            
+            case tasks.Type.Int:
+                fallthrough
+            case tasks.Type.Int__Repr:
+                return union__Any__Int
+            
+            
+            case tasks.Type.Float:
+                fallthrough
+            case tasks.Type.Float__Repr:
+                return union__Any__Float
+            
+            
+            case tasks.Type.String:
+                fallthrough
+            case tasks.Type.String__Repr:
+                return union__Any__String
+            
+            
+            case tasks.Type.Bytes:
+                fallthrough
+            case tasks.Type.Bytes__Repr:
+                return union__Any__Bytes
+            
+            
+            case tasks.Type.Map:
+                fallthrough
+            case tasks.Type.Map__Repr:
+                return union__Any__Map
+            
+            
+            case tasks.Type.List:
+                fallthrough
+            case tasks.Type.List__Repr:
+                return union__Any__List
+            
+            
+            case tasks.Type.Link:
+                fallthrough
+            case tasks.Type.Link__Repr:
+                return union__Any__Link
+            
+            }				
+        }
+        fmt.Printf("Actual type %T: %v not in union\n", p.Value, p.Value)
+        return nil
+    },
+})
+
+var union__Any__Bool = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Bool",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.Boolean,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Bool)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsBool()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__Int = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Int",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.Int,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Int)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsInt()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__Float = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Float",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.Float,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Float)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsFloat()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__String = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.String",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.String,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.String)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsString()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__Bytes = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Bytes",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+
+var union__Any__Map = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Map",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+
+var union__Any__List = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.List",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+
+var union__Any__Link = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Link",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+func Time__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        i, err := value.AsInt()
+        if err != nil {
+            return err
+        }
+        return i
+        
+    default:
+        return nil
+    }
+}
+func Time__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Time__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Time__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Time__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Time__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Time",
+    Description: "Time",
+    Serialize: Time__type__serialize,
+    ParseValue: Time__type__parse,
+    ParseLiteral: Time__type__parseLiteral,
+})
+func RecordUpdate__Records__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldRecords(), nil
+    
+}
+func RecordUpdate__SigPrev__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSigPrev(), nil
+    
+}
+func RecordUpdate__Previous__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldPrevious()
+    if f.Exists() {
+        
+        return "IS a link", nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "RecordUpdate",
+    Fields: graphql.Fields{
+        "Records": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_AuthenticatedRecord__type),
+            
+            Resolve: RecordUpdate__Records__resolve,
+        },
+        "SigPrev": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Bytes__type),
+            
+            Resolve: RecordUpdate__SigPrev__resolve,
+        },
+        "Previous": &graphql.Field{
+            
+            Type: graphql.ID,
+            
+            Resolve: RecordUpdate__Previous__resolve,
+        },
+    },
+})
+func Bytes__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        b, err := value.AsBytes()
+        if err != nil {
+            return err
+        }
+        return b
+        
+    default:
+        return nil
+    }
+}
+func Bytes__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Bytes__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Bytes__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Bytes__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Bytes",
+    Description: "Bytes",
+    Serialize: Bytes__type__serialize,
+    ParseValue: Bytes__type__parse,
+    ParseLiteral: Bytes__type__parseLiteral,
+})
+var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_Logs",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Logs__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
 func StorageTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.StorageTask)
     if !ok {
@@ -1042,85 +943,6 @@ var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
-func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStage()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldCurrentStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func UpdateTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldWorkedBy().AsString()
-    
-}
-var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "UpdateTask",
-    Fields: graphql.Fields{
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: UpdateTask__Status__resolve,
-        },
-        "Stage": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: UpdateTask__Stage__resolve,
-        },
-        "CurrentStageDetails": &graphql.Field{
-            
-            Type: StageDetails__type,
-            
-            Resolve: UpdateTask__CurrentStageDetails__resolve,
-        },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: UpdateTask__WorkedBy__resolve,
-        },
-    },
-})
 func AuthenticatedRecord__Record__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.AuthenticatedRecord)
     if !ok {
@@ -1178,6 +1000,534 @@ var AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
             Type: graphql.NewNonNull(Bytes__type),
             
             Resolve: AuthenticatedRecord__Signature__resolve,
+        },
+    },
+})
+func Logs__Log__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Logs)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldLog().AsString()
+    
+}
+func Logs__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Logs)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldUpdatedAt(), nil
+    
+}
+var Logs__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Logs",
+    Fields: graphql.Fields{
+        "Log": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Logs__Log__resolve,
+        },
+        "UpdatedAt": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Time__type),
+            
+            Resolve: Logs__UpdatedAt__resolve,
+        },
+    },
+})
+var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Tasks",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Task__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func PopTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.PopTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStatus(), nil
+    
+}
+func PopTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.PopTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldWorkedBy().AsString()
+    
+}
+var PopTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "PopTask",
+    Fields: graphql.Fields{
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: PopTask__Status__resolve,
+        },
+        "WorkedBy": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: PopTask__WorkedBy__resolve,
+        },
+    },
+})
+var List__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Any__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_StageDetails",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: StageDetails__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(StageDetails__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(StageDetails__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func Status__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        i, err := value.AsInt()
+        if err != nil {
+            return err
+        }
+        return i
+        
+    default:
+        return nil
+    }
+}
+func Status__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Status__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Status__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Status__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Status__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Status",
+    Description: "Status",
+    Serialize: Status__type__serialize,
+    ParseValue: Status__type__parse,
+    ParseLiteral: Status__type__parseLiteral,
+})
+func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldDescription()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldExpectedDuration()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldLogs(), nil
+    
+}
+func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldUpdatedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "StageDetails",
+    Fields: graphql.Fields{
+        "Description": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__Description__resolve,
+        },
+        "ExpectedDuration": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__ExpectedDuration__resolve,
+        },
+        "Logs": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_Logs__type),
+            
+            Resolve: StageDetails__Logs__resolve,
+        },
+        "UpdatedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: StageDetails__UpdatedAt__resolve,
+        },
+    },
+})
+func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMiner().AsString()
+    
+}
+func RetrievalTask__PayloadCID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldPayloadCID().AsString()
+    
+}
+func RetrievalTask__CARExport__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldCARExport().AsBool()
+    
+}
+var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "RetrievalTask",
+    Fields: graphql.Fields{
+        "Miner": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: RetrievalTask__Miner__resolve,
+        },
+        "PayloadCID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: RetrievalTask__PayloadCID__resolve,
+        },
+        "CARExport": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: RetrievalTask__CARExport__resolve,
         },
     },
 })
@@ -1411,428 +1761,85 @@ var FinishedTask__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
-func Time__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        i, err := value.AsInt()
-        if err != nil {
-            return err
-        }
-        return i
-        
-    default:
-        return nil
-    }
-}
-func Time__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Time__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Time__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Time__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Time__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Time",
-    Description: "Time",
-    Serialize: Time__type__serialize,
-    ParseValue: Time__type__parse,
-    ParseLiteral: Time__type__parseLiteral,
-})
-func Logs__Log__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Logs)
+func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
     if !ok {
         return nil, errNotNode
     }
     
-    return ts.FieldLog().AsString()
+    return ts.FieldStatus(), nil
     
 }
-func Logs__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Logs)
+func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
     if !ok {
         return nil, errNotNode
     }
     
-    return ts.FieldUpdatedAt(), nil
+    f := ts.FieldStage()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
     
 }
-var Logs__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Logs",
+func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldCurrentStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func UpdateTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldWorkedBy().AsString()
+    
+}
+var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "UpdateTask",
     Fields: graphql.Fields{
-        "Log": &graphql.Field{
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: UpdateTask__Status__resolve,
+        },
+        "Stage": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: UpdateTask__Stage__resolve,
+        },
+        "CurrentStageDetails": &graphql.Field{
+            
+            Type: StageDetails__type,
+            
+            Resolve: UpdateTask__CurrentStageDetails__resolve,
+        },
+        "WorkedBy": &graphql.Field{
             
             Type: graphql.NewNonNull(graphql.String),
             
-            Resolve: Logs__Log__resolve,
-        },
-        "UpdatedAt": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Time__type),
-            
-            Resolve: Logs__UpdatedAt__resolve,
+            Resolve: UpdateTask__WorkedBy__resolve,
         },
     },
 })
-func RecordUpdate__Records__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RecordUpdate)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldRecords(), nil
-    
-}
-func RecordUpdate__SigPrev__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RecordUpdate)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldSigPrev(), nil
-    
-}
-func RecordUpdate__Previous__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RecordUpdate)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldPrevious(), nil
-    
-}
-var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "RecordUpdate",
-    Fields: graphql.Fields{
-        "Records": &graphql.Field{
-            
-            Type: graphql.NewNonNull(List_AuthenticatedRecord__type),
-            
-            Resolve: RecordUpdate__Records__resolve,
-        },
-        "SigPrev": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Bytes__type),
-            
-            Resolve: RecordUpdate__SigPrev__resolve,
-        },
-        "Previous": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.ID),
-            
-            Resolve: RecordUpdate__Previous__resolve,
-        },
-    },
-})
-var Any__type = graphql.NewUnion(graphql.UnionConfig{
-    Name: "Any",
-    Types: []*graphql.Object{
-        
-        union__Any__Bool,
-        
-        
-        union__Any__Int,
-        
-        
-        union__Any__Float,
-        
-        
-        union__Any__String,
-        
-        
-        union__Any__Bytes,
-        
-        
-        union__Any__Map,
-        
-        
-        union__Any__List,
-        
-        
-        union__Any__Link,
-        
-    },
-    ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
-        if node, ok := p.Value.(ipld.Node); ok {
-            switch node.Prototype() {
-            
-            case tasks.Type.Bool:
-                fallthrough
-            case tasks.Type.Bool__Repr:
-                return union__Any__Bool
-            
-            
-            case tasks.Type.Int:
-                fallthrough
-            case tasks.Type.Int__Repr:
-                return union__Any__Int
-            
-            
-            case tasks.Type.Float:
-                fallthrough
-            case tasks.Type.Float__Repr:
-                return union__Any__Float
-            
-            
-            case tasks.Type.String:
-                fallthrough
-            case tasks.Type.String__Repr:
-                return union__Any__String
-            
-            
-            case tasks.Type.Bytes:
-                fallthrough
-            case tasks.Type.Bytes__Repr:
-                return union__Any__Bytes
-            
-            
-            case tasks.Type.Map:
-                fallthrough
-            case tasks.Type.Map__Repr:
-                return union__Any__Map
-            
-            
-            case tasks.Type.List:
-                fallthrough
-            case tasks.Type.List__Repr:
-                return union__Any__List
-            
-            
-            case tasks.Type.Link:
-                fallthrough
-            case tasks.Type.Link__Repr:
-                return union__Any__Link
-            
-            }				
-        }
-        fmt.Printf("Actual type %T: %v not in union\n", p.Value, p.Value)
-        return nil
-    },
-})
-
-var union__Any__Bool = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Bool",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.Boolean,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Bool)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsBool()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__Int = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Int",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.Int,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Int)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsInt()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__Float = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Float",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.Float,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Float)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsFloat()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__String = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.String",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.String,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.String)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsString()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__Bytes = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Bytes",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-
-var union__Any__Map = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Map",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-
-var union__Any__List = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.List",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-
-var union__Any__Link = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Link",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Tasks",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Task__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
 
 func init() {
 

--- a/controller/graphql/schema.go
+++ b/controller/graphql/schema.go
@@ -36,6 +36,363 @@ func resolve_map_at(p graphql.ResolveParams) (interface{}, error) {
         return nil, fmt.Errorf("unknown key type: %T", arg)
     }
 }
+var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_Logs",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Logs__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func PopTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.PopTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStatus(), nil
+    
+}
+func PopTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.PopTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldWorkedBy().AsString()
+    
+}
+var PopTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "PopTask",
+    Fields: graphql.Fields{
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: PopTask__Status__resolve,
+        },
+        "WorkedBy": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: PopTask__WorkedBy__resolve,
+        },
+    },
+})
+var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_AuthenticatedRecord",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: AuthenticatedRecord__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(AuthenticatedRecord__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(AuthenticatedRecord__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func Bytes__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        b, err := value.AsBytes()
+        if err != nil {
+            return err
+        }
+        return b
+        
+    default:
+        return nil
+    }
+}
+func Bytes__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Bytes__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Bytes__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Bytes__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Bytes",
+    Description: "Bytes",
+    Serialize: Bytes__type__serialize,
+    ParseValue: Bytes__type__parse,
+    ParseLiteral: Bytes__type__parseLiteral,
+})
+var List__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Any__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
 func Status__type__serialize(value interface{}) interface{} {
     switch value := value.(type) {
     case ipld.Node:
@@ -78,6 +435,199 @@ var Status__type = graphql.NewScalar(graphql.ScalarConfig{
     Serialize: Status__type__serialize,
     ParseValue: Status__type__parse,
     ParseLiteral: Status__type__parseLiteral,
+})
+var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_StageDetails",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: StageDetails__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(StageDetails__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(StageDetails__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+var Map__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Map",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Any__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.String),
+                },
+            },	
+            Resolve: resolve_map_at,
+        },
+        "Keys": &graphql.Field{
+            Type: graphql.NewList(graphql.String),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    node, _, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    children = append(children, node)
+                }
+                return children, nil
+            },
+        },
+        "Values": &graphql.Field{
+            Type: graphql.NewList(Any__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Map__type__entry),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.MapIterator()
+                children := make([][]ipld.Node, 0)
+
+                for !it.Done() {
+                    k, v, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    children = append(children, []ipld.Node{k, v})
+                }
+                return children, nil
+            },
+        },
+    },	
+})
+var Map__type__entry = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Map_Entry",
+    Fields: graphql.Fields{
+        "Key": &graphql.Field{
+            Type: graphql.String,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                kv, ok := p.Source.([]ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return kv[0], nil
+            },
+        },
+        "Value": &graphql.Field{
+            Type: Any__type,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                kv, ok := p.Source.([]ipld.Node)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return kv[1], nil
+            },
+        },
+    },
 })
 func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.RetrievalTask)
@@ -126,6 +676,508 @@ var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
             Type: graphql.NewNonNull(graphql.Boolean),
             
             Resolve: RetrievalTask__CARExport__resolve,
+        },
+    },
+})
+func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldUUID().AsString()
+    
+}
+func Task__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStatus(), nil
+    
+}
+func Task__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldWorkedBy()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStage().AsString()
+    
+}
+func Task__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldCurrentStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__PastStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldPastStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStartedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldRetrievalTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStorageTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var Task__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Task",
+    Fields: graphql.Fields{
+        "UUID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Task__UUID__resolve,
+        },
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: Task__Status__resolve,
+        },
+        "WorkedBy": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: Task__WorkedBy__resolve,
+        },
+        "Stage": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Task__Stage__resolve,
+        },
+        "CurrentStageDetails": &graphql.Field{
+            
+            Type: StageDetails__type,
+            
+            Resolve: Task__CurrentStageDetails__resolve,
+        },
+        "PastStageDetails": &graphql.Field{
+            
+            Type: List_StageDetails__type,
+            
+            Resolve: Task__PastStageDetails__resolve,
+        },
+        "StartedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: Task__StartedAt__resolve,
+        },
+        "RetrievalTask": &graphql.Field{
+            
+            Type: RetrievalTask__type,
+            
+            Resolve: Task__RetrievalTask__resolve,
+        },
+        "StorageTask": &graphql.Field{
+            
+            Type: StorageTask__type,
+            
+            Resolve: Task__StorageTask__resolve,
+        },
+    },
+})
+func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldDescription()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldExpectedDuration()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldLogs(), nil
+    
+}
+func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldUpdatedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "StageDetails",
+    Fields: graphql.Fields{
+        "Description": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__Description__resolve,
+        },
+        "ExpectedDuration": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__ExpectedDuration__resolve,
+        },
+        "Logs": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_Logs__type),
+            
+            Resolve: StageDetails__Logs__resolve,
+        },
+        "UpdatedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: StageDetails__UpdatedAt__resolve,
+        },
+    },
+})
+func StorageTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMiner().AsString()
+    
+}
+func StorageTask__MaxPriceAttoFIL__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMaxPriceAttoFIL().AsInt()
+    
+}
+func StorageTask__Size__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSize().AsInt()
+    
+}
+func StorageTask__StartOffset__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStartOffset().AsInt()
+    
+}
+func StorageTask__FastRetrieval__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldFastRetrieval().AsBool()
+    
+}
+func StorageTask__Verified__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldVerified().AsBool()
+    
+}
+var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "StorageTask",
+    Fields: graphql.Fields{
+        "Miner": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: StorageTask__Miner__resolve,
+        },
+        "MaxPriceAttoFIL": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: StorageTask__MaxPriceAttoFIL__resolve,
+        },
+        "Size": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: StorageTask__Size__resolve,
+        },
+        "StartOffset": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: StorageTask__StartOffset__resolve,
+        },
+        "FastRetrieval": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: StorageTask__FastRetrieval__resolve,
+        },
+        "Verified": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: StorageTask__Verified__resolve,
+        },
+    },
+})
+func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStatus(), nil
+    
+}
+func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStage()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldCurrentStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func UpdateTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.UpdateTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldWorkedBy().AsString()
+    
+}
+var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "UpdateTask",
+    Fields: graphql.Fields{
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: UpdateTask__Status__resolve,
+        },
+        "Stage": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: UpdateTask__Stage__resolve,
+        },
+        "CurrentStageDetails": &graphql.Field{
+            
+            Type: StageDetails__type,
+            
+            Resolve: UpdateTask__CurrentStageDetails__resolve,
+        },
+        "WorkedBy": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: UpdateTask__WorkedBy__resolve,
+        },
+    },
+})
+func AuthenticatedRecord__Record__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.AuthenticatedRecord)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    targetCid := ts.FieldRecord().Link()
+    
+			var node ipld.Node
+			
+	if cl, ok := targetCid.(cidlink.Link); ok {
+		v := p.Context.Value(nodeLoaderCtxKey)
+		if v == nil {
+			return cl.Cid, nil
+		}
+		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
+		if !ok {
+			return nil, errInvalidLoader
+		}
+
+		builder := tasks.Type.FinishedTask__Repr.NewBuilder()
+		n, err := loader(p.Context, cl, builder);
+		if err != nil {
+			return nil, err
+		}
+		node = n
+	} else {
+		return nil, errInvalidLink
+	}
+	
+			return node, nil
+			
+    
+}
+func AuthenticatedRecord__Signature__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.AuthenticatedRecord)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSignature(), nil
+    
+}
+var AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "AuthenticatedRecord",
+    Fields: graphql.Fields{
+        "Record": &graphql.Field{
+            
+            Type: graphql.NewNonNull(FinishedTask__type),
+            
+            Resolve: AuthenticatedRecord__Record__resolve,
+        },
+        "Signature": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Bytes__type),
+            
+            Resolve: AuthenticatedRecord__Signature__resolve,
         },
     },
 })
@@ -359,453 +1411,6 @@ var FinishedTask__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
-func UpdateTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func UpdateTask__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStage()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func UpdateTask__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldCurrentStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func UpdateTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.UpdateTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldWorkedBy().AsString()
-    
-}
-var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "UpdateTask",
-    Fields: graphql.Fields{
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: UpdateTask__Status__resolve,
-        },
-        "Stage": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: UpdateTask__Stage__resolve,
-        },
-        "CurrentStageDetails": &graphql.Field{
-            
-            Type: StageDetails__type,
-            
-            Resolve: UpdateTask__CurrentStageDetails__resolve,
-        },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: UpdateTask__WorkedBy__resolve,
-        },
-    },
-})
-var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_StageDetails",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: StageDetails__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(StageDetails__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(StageDetails__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_Logs",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Logs__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldUUID().AsString()
-    
-}
-func Task__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func Task__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldWorkedBy()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStage().AsString()
-    
-}
-func Task__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldCurrentStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__PastStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldPastStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStartedAt()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldRetrievalTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStorageTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var Task__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Task",
-    Fields: graphql.Fields{
-        "UUID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__UUID__resolve,
-        },
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: Task__Status__resolve,
-        },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: Task__WorkedBy__resolve,
-        },
-        "Stage": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__Stage__resolve,
-        },
-        "CurrentStageDetails": &graphql.Field{
-            
-            Type: StageDetails__type,
-            
-            Resolve: Task__CurrentStageDetails__resolve,
-        },
-        "PastStageDetails": &graphql.Field{
-            
-            Type: List_StageDetails__type,
-            
-            Resolve: Task__PastStageDetails__resolve,
-        },
-        "StartedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: Task__StartedAt__resolve,
-        },
-        "RetrievalTask": &graphql.Field{
-            
-            Type: RetrievalTask__type,
-            
-            Resolve: Task__RetrievalTask__resolve,
-        },
-        "StorageTask": &graphql.Field{
-            
-            Type: StorageTask__type,
-            
-            Resolve: Task__StorageTask__resolve,
-        },
-    },
-})
 func Time__type__serialize(value interface{}) interface{} {
     switch value := value.(type) {
     case ipld.Node:
@@ -848,476 +1453,6 @@ var Time__type = graphql.NewScalar(graphql.ScalarConfig{
     Serialize: Time__type__serialize,
     ParseValue: Time__type__parse,
     ParseLiteral: Time__type__parseLiteral,
-})
-func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldDescription()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldExpectedDuration()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldLogs(), nil
-    
-}
-func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldUpdatedAt()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "StageDetails",
-    Fields: graphql.Fields{
-        "Description": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: StageDetails__Description__resolve,
-        },
-        "ExpectedDuration": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: StageDetails__ExpectedDuration__resolve,
-        },
-        "Logs": &graphql.Field{
-            
-            Type: graphql.NewNonNull(List_Logs__type),
-            
-            Resolve: StageDetails__Logs__resolve,
-        },
-        "UpdatedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: StageDetails__UpdatedAt__resolve,
-        },
-    },
-})
-var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_AuthenticatedRecord",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: AuthenticatedRecord__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(AuthenticatedRecord__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(AuthenticatedRecord__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func StorageTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMiner().AsString()
-    
-}
-func StorageTask__MaxPriceAttoFIL__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMaxPriceAttoFIL().AsInt()
-    
-}
-func StorageTask__Size__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldSize().AsInt()
-    
-}
-func StorageTask__StartOffset__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStartOffset().AsInt()
-    
-}
-func StorageTask__FastRetrieval__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldFastRetrieval().AsBool()
-    
-}
-func StorageTask__Verified__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StorageTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldVerified().AsBool()
-    
-}
-var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "StorageTask",
-    Fields: graphql.Fields{
-        "Miner": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: StorageTask__Miner__resolve,
-        },
-        "MaxPriceAttoFIL": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: StorageTask__MaxPriceAttoFIL__resolve,
-        },
-        "Size": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: StorageTask__Size__resolve,
-        },
-        "StartOffset": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: StorageTask__StartOffset__resolve,
-        },
-        "FastRetrieval": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: StorageTask__FastRetrieval__resolve,
-        },
-        "Verified": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: StorageTask__Verified__resolve,
-        },
-    },
-})
-var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Tasks",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Task__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func AuthenticatedRecord__Record__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.AuthenticatedRecord)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    targetCid := ts.FieldRecord().Link()
-    
-			var node ipld.Node
-			
-	if cl, ok := targetCid.(cidlink.Link); ok {
-		v := p.Context.Value(nodeLoaderCtxKey)
-		if v == nil {
-			return cl.Cid, nil
-		}
-		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
-		if !ok {
-			return nil, errInvalidLoader
-		}
-
-		builder := tasks.Type.FinishedTask__Repr.NewBuilder()
-		n, err := loader(p.Context, cl, builder);
-		if err != nil {
-			return nil, err
-		}
-		node = n
-	} else {
-		return nil, errInvalidLink
-	}
-	
-			return node, nil
-			
-    
-}
-func AuthenticatedRecord__Signature__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.AuthenticatedRecord)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldSignature(), nil
-    
-}
-var AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "AuthenticatedRecord",
-    Fields: graphql.Fields{
-        "Record": &graphql.Field{
-            
-            Type: graphql.NewNonNull(FinishedTask__type),
-            
-            Resolve: AuthenticatedRecord__Record__resolve,
-        },
-        "Signature": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Bytes__type),
-            
-            Resolve: AuthenticatedRecord__Signature__resolve,
-        },
-    },
-})
-func Bytes__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        b, err := value.AsBytes()
-        if err != nil {
-            return err
-        }
-        return b
-        
-    default:
-        return nil
-    }
-}
-func Bytes__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Bytes__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Bytes__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Bytes__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Bytes",
-    Description: "Bytes",
-    Serialize: Bytes__type__serialize,
-    ParseValue: Bytes__type__parse,
-    ParseLiteral: Bytes__type__parseLiteral,
 })
 func Logs__Log__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.Logs)
@@ -1363,6 +1498,15 @@ func RecordUpdate__Records__resolve(p graphql.ResolveParams) (interface{}, error
     return ts.FieldRecords(), nil
     
 }
+func RecordUpdate__SigPrev__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSigPrev(), nil
+    
+}
 func RecordUpdate__Previous__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.RecordUpdate)
     if !ok {
@@ -1381,6 +1525,12 @@ var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
             
             Resolve: RecordUpdate__Records__resolve,
         },
+        "SigPrev": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Bytes__type),
+            
+            Resolve: RecordUpdate__SigPrev__resolve,
+        },
         "Previous": &graphql.Field{
             
             Type: graphql.NewNonNull(graphql.ID),
@@ -1389,199 +1539,6 @@ var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
-var Map__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Map",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Any__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.String),
-                },
-            },	
-            Resolve: resolve_map_at,
-        },
-        "Keys": &graphql.Field{
-            Type: graphql.NewList(graphql.String),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    node, _, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    children = append(children, node)
-                }
-                return children, nil
-            },
-        },
-        "Values": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Map__type__entry),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.MapIterator()
-                children := make([][]ipld.Node, 0)
-
-                for !it.Done() {
-                    k, v, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    children = append(children, []ipld.Node{k, v})
-                }
-                return children, nil
-            },
-        },
-    },	
-})
-var Map__type__entry = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Map_Entry",
-    Fields: graphql.Fields{
-        "Key": &graphql.Field{
-            Type: graphql.String,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                kv, ok := p.Source.([]ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return kv[0], nil
-            },
-        },
-        "Value": &graphql.Field{
-            Type: Any__type,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                kv, ok := p.Source.([]ipld.Node)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return kv[1], nil
-            },
-        },
-    },
-})
-var List__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Any__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Any__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
 var Any__type = graphql.NewUnion(graphql.UnionConfig{
     Name: "Any",
     Types: []*graphql.Object{
@@ -1783,41 +1740,99 @@ var union__Any__Link = graphql.NewObject(graphql.ObjectConfig{
     },
 })
 
-func PopTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.PopTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func PopTask__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.PopTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldWorkedBy().AsString()
-    
-}
-var PopTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "PopTask",
+var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Tasks",
     Fields: graphql.Fields{
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: PopTask__Status__resolve,
+        "At": &graphql.Field{
+            Type: Task__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
         },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: PopTask__WorkedBy__resolve,
+        "All": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
         },
     },
-})
+})	
 
 func init() {
 

--- a/controller/graphql/server.go
+++ b/controller/graphql/server.go
@@ -40,6 +40,16 @@ func GetHandler(db state.State) (*http.ServeMux, error) {
 						return tasks.Type.Tasks.Of(tsks), nil
 					},
 				},
+				"RecordUpdate": &graphql.Field{
+					Type: RecordUpdate__type,
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+						hd, err := db.GetHead(p.Context)
+						if err != nil {
+							return nil, err
+						}
+						return hd, nil
+					},
+				},
 			},
 		}),
 	})

--- a/controller/state/interface.go
+++ b/controller/state/interface.go
@@ -11,6 +11,7 @@ type State interface {
 	AssignTask(ctx context.Context, req tasks.PopTask) (tasks.Task, error)
 	Get(ctx context.Context, uuid string) (tasks.Task, error)
 	GetAll(ctx context.Context) ([]tasks.Task, error)
+	GetHead(ctx context.Context) (tasks.RecordUpdate, error)
 	Update(ctx context.Context, uuid string, req tasks.UpdateTask) (tasks.Task, error)
 	NewStorageTask(ctx context.Context, storageTask tasks.StorageTask) (tasks.Task, error)
 	NewRetrievalTask(ctx context.Context, retrievalTask tasks.RetrievalTask) (tasks.Task, error)

--- a/controller/state/interface.go
+++ b/controller/state/interface.go
@@ -16,4 +16,5 @@ type State interface {
 	NewStorageTask(ctx context.Context, storageTask tasks.StorageTask) (tasks.Task, error)
 	NewRetrievalTask(ctx context.Context, retrievalTask tasks.RetrievalTask) (tasks.Task, error)
 	DrainWorker(ctx context.Context, worker string) error
+	PublishRecordsFrom(ctx context.Context, worker string) error
 }

--- a/controller/state/migrations/000004_initialize_schema.down.sql
+++ b/controller/state/migrations/000004_initialize_schema.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS record_updates;
+
+COMMIT;

--- a/controller/state/migrations/000004_initialize_schema.up.sql
+++ b/controller/state/migrations/000004_initialize_schema.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+create table record_updates (
+    cid varchar(255) NOT NULL,
+    created timestamp NOT NULL,
+    worked_by text,
+    status int,
+    PRIMARY KEY (status, created)
+);
+
+COMMIT;

--- a/controller/state/record_update.go
+++ b/controller/state/record_update.go
@@ -1,0 +1,10 @@
+package state
+
+type record_update_status int
+
+const (
+	LATEST_UPDATE     record_update_status = 1
+	PREVIOUS_UPDATE   record_update_status = 2
+	UNATTACHED_RECORD record_update_status = 10
+	ATTACHED_RECORD   record_update_status = 11
+)

--- a/controller/state/record_update.go
+++ b/controller/state/record_update.go
@@ -1,10 +1,10 @@
 package state
 
-type record_update_status int
+type RecordUpdateStatus int
 
 const (
-	LATEST_UPDATE     record_update_status = 1
-	PREVIOUS_UPDATE   record_update_status = 2
-	UNATTACHED_RECORD record_update_status = 10
-	ATTACHED_RECORD   record_update_status = 11
+	LATEST_UPDATE     RecordUpdateStatus = 1
+	PREVIOUS_UPDATE   RecordUpdateStatus = 2
+	UNATTACHED_RECORD RecordUpdateStatus = 10
+	ATTACHED_RECORD   RecordUpdateStatus = 11
 )

--- a/controller/state/statedb.go
+++ b/controller/state/statedb.go
@@ -357,7 +357,11 @@ func (s *stateDB) Update(ctx context.Context, taskID string, req tasks.UpdateTas
 				return err
 			}
 
-			if _, err = tx.ExecContext(ctx, addHeadSQL, flink.(linksystem.Link).Cid.String(), time.Now(), req.WorkedBy.String(), UNATTACHED_RECORD); err != nil {
+			if _, err := tx.ExecContext(ctx, addHeadSQL,
+				flink.(linksystem.Link).Cid.String(),
+				time.Now(),
+				req.WorkedBy.String(),
+				UNATTACHED_RECORD); err != nil {
 				return err
 			}
 		}
@@ -570,7 +574,7 @@ func (s *stateDB) PublishRecordsFrom(ctx context.Context, worker string) error {
 		if err := itms.Scan(&lnk); err != nil {
 			return err
 		}
-		if _, err = tx.ExecContext(ctx, updateHeadSQL, ATTACHED_RECORD, lnk); err != nil {
+		if _, err := tx.ExecContext(ctx, updateHeadSQL, ATTACHED_RECORD, lnk); err != nil {
 			return err
 		}
 		sig, err := s.PrivKey.Sign([]byte(lnk))

--- a/controller/state/statedb.go
+++ b/controller/state/statedb.go
@@ -472,3 +472,8 @@ func (s *stateDB) countTasks(ctx context.Context) (int, error) {
 	}
 	return count, nil
 }
+
+// GetHead gets the latest record update from the controller.
+func (s *stateDB) GetHead(ctx context.Context) (tasks.RecordUpdate, error) {
+	return nil, nil
+}

--- a/controller/state/statedb_dml.go
+++ b/controller/state/statedb_dml.go
@@ -58,11 +58,27 @@ const (
 		INSERT INTO finalizedData (cid, data, created) VALUES($1, $2, $3)
 	`
 
+	cidGetArchiveSQL = `
+		SELECT data FROM finalizedData WHERE cid = $1
+	`
+
 	drainedAddSQL = `
 		INSERT INTO drained_workers (worked_by) VALUES ($1)
 	`
 
 	drainedQuerySQL = `
 		SELECT COUNT(*) as cnt FROM drained_workers WHERE worked_by = $1
+	`
+
+	addHeadSQL = `
+		INSERT INTO record_updates (cid, created, worked_by, status) VALUES ($1, $2, $3, $4)
+	`
+
+	updateHeadSQL = `
+		UPDATE record_updates SET status = $1 WHERE cid = $2
+	`
+
+	queryHeadSQL = `
+		SELECT cid FROM record_updates WHERE status = $1 AND worked_by = $2
 	`
 )

--- a/tasks/gen.go
+++ b/tasks/gen.go
@@ -147,6 +147,7 @@ func main() {
 	ts.Accumulate(schema.SpawnList("List_AuthenticatedRecord", "AuthenticatedRecord", false))
 	ts.Accumulate(schema.SpawnStruct("RecordUpdate", []schema.StructField{
 		schema.SpawnStructField("Records", "List_AuthenticatedRecord", false, false),
+		schema.SpawnStructField("SigPrev", "Bytes", false, false),
 		schema.SpawnStructField("Previous", "Link", false, false),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
 

--- a/tasks/gen.go
+++ b/tasks/gen.go
@@ -148,7 +148,7 @@ func main() {
 	ts.Accumulate(schema.SpawnStruct("RecordUpdate", []schema.StructField{
 		schema.SpawnStructField("Records", "List_AuthenticatedRecord", false, false),
 		schema.SpawnStructField("SigPrev", "Bytes", false, false),
-		schema.SpawnStructField("Previous", "Link", false, false),
+		schema.SpawnStructField("Previous", "Link", false, true),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
 
 	if errs := ts.ValidateGraph(); errs != nil {

--- a/tasks/gen.go
+++ b/tasks/gen.go
@@ -125,6 +125,7 @@ func main() {
 		schema.SpawnStructField("TimeToLastByteMS", "Int", true, false),
 		schema.SpawnStructField("Events", "Link_List_StageDetails", false, false),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
+	ts.Accumulate(schema.SpawnLinkReference("Link_FinishedTask", "FinishedTask"))
 
 	// client api
 	ts.Accumulate(schema.SpawnStruct("PopTask", []schema.StructField{
@@ -136,6 +137,17 @@ func main() {
 		schema.SpawnStructField("Stage", "String", true, false),
 		schema.SpawnStructField("CurrentStageDetails", "StageDetails", true, false),
 		schema.SpawnStructField("WorkedBy", "String", false, false),
+	}, schema.SpawnStructRepresentationMap(map[string]string{})))
+
+	// reputation api
+	ts.Accumulate(schema.SpawnStruct("AuthenticatedRecord", []schema.StructField{
+		schema.SpawnStructField("Record", "Link_FinishedTask", false, false),
+		schema.SpawnStructField("Signature", "Bytes", false, false),
+	}, schema.SpawnStructRepresentationMap(map[string]string{})))
+	ts.Accumulate(schema.SpawnList("List_AuthenticatedRecord", "AuthenticatedRecord", false))
+	ts.Accumulate(schema.SpawnStruct("RecordUpdate", []schema.StructField{
+		schema.SpawnStructField("Records", "List_AuthenticatedRecord", false, false),
+		schema.SpawnStructField("Previous", "Link", false, false),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
 
 	if errs := ts.ValidateGraph(); errs != nil {

--- a/tasks/ipldsch_satisfaction.go
+++ b/tasks/ipldsch_satisfaction.go
@@ -10247,7 +10247,7 @@ func (n _RecordUpdate) FieldRecords() List_AuthenticatedRecord {
 func (n _RecordUpdate) FieldSigPrev() Bytes {
 	return &n.SigPrev
 }
-func (n _RecordUpdate) FieldPrevious() Link {
+func (n _RecordUpdate) FieldPrevious() MaybeLink {
 	return &n.Previous
 }
 type _RecordUpdate__Maybe struct {
@@ -10300,7 +10300,10 @@ func (n RecordUpdate) LookupByString(key string) (ipld.Node, error) {
 	case "SigPrev":
 		return &n.SigPrev, nil
 	case "Previous":
-		return &n.Previous, nil
+		if n.Previous.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Previous.v, nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -10340,7 +10343,11 @@ func (itr *_RecordUpdate__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 		v = &itr.n.SigPrev
 	case 2:
 		k = &fieldName__RecordUpdate_Previous
-		v = &itr.n.Previous
+		if itr.n.Previous.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Previous.v
 	default:
 		panic("unreachable")
 	}
@@ -10544,10 +10551,12 @@ func (ma *_RecordUpdate__Assembler) valueFinishTidy() bool {
 			return false
 		}
 	case 2:
-		switch ma.cm {
+		switch ma.w.Previous.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Previous.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Previous.v = ma.ca_Previous.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -10600,8 +10609,9 @@ func (ma *_RecordUpdate__Assembler) AssembleEntry(k string) (ipld.NodeAssembler,
 		ma.s += fieldBit__RecordUpdate_Previous
 		ma.state = maState_midValue
 		ma.f = 2
-		ma.ca_Previous.w = &ma.w.Previous
-		ma.ca_Previous.m = &ma.cm
+		ma.ca_Previous.w = ma.w.Previous.v
+		ma.ca_Previous.m = &ma.w.Previous.m
+		ma.w.Previous.m = allowNull
 		return &ma.ca_Previous, nil
 	default:
 		return nil, ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate", Key:&_String{k}}
@@ -10649,8 +10659,9 @@ func (ma *_RecordUpdate__Assembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_SigPrev.m = &ma.cm
 		return &ma.ca_SigPrev
 	case 2:
-		ma.ca_Previous.w = &ma.w.Previous
-		ma.ca_Previous.m = &ma.cm
+		ma.ca_Previous.w = ma.w.Previous.v
+		ma.ca_Previous.m = &ma.w.Previous.m
+		ma.w.Previous.m = allowNull
 		return &ma.ca_Previous
 	default:
 		panic("unreachable")
@@ -10678,9 +10689,6 @@ func (ma *_RecordUpdate__Assembler) Finish() error {
 		}
 		if ma.s & fieldBit__RecordUpdate_SigPrev == 0 {
 			err.Missing = append(err.Missing, "SigPrev")
-		}
-		if ma.s & fieldBit__RecordUpdate_Previous == 0 {
-			err.Missing = append(err.Missing, "Previous")
 		}
 		return err
 	}
@@ -10783,7 +10791,10 @@ func (n *_RecordUpdate__Repr) LookupByString(key string) (ipld.Node, error) {
 	case "SigPrev":
 		return n.SigPrev.Representation(), nil
 	case "Previous":
-		return n.Previous.Representation(), nil
+		if n.Previous.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Previous.v.Representation(), nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -10824,7 +10835,11 @@ if itr.idx >= 3 {
 		v = itr.n.SigPrev.Representation()
 	case 2:
 		k = &fieldName__RecordUpdate_Previous_serial
-		v = itr.n.Previous.Representation()
+		if itr.n.Previous.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Previous.v.Representation()
 	default:
 		panic("unreachable")
 	}
@@ -11017,8 +11032,12 @@ func (ma *_RecordUpdate__ReprAssembler) valueFinishTidy() bool {
 			return false
 		}
 	case 2:
-		switch ma.cm {
-		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+		switch ma.w.Previous.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
+		case schema.Maybe_Value:
+			ma.w.Previous.v = ma.ca_Previous.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -11071,8 +11090,9 @@ func (ma *_RecordUpdate__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssemb
 		ma.s += fieldBit__RecordUpdate_Previous
 		ma.state = maState_midValue
 		ma.f = 2
-		ma.ca_Previous.w = &ma.w.Previous
-		ma.ca_Previous.m = &ma.cm
+		ma.ca_Previous.w = ma.w.Previous.v
+		ma.ca_Previous.m = &ma.w.Previous.m
+		ma.w.Previous.m = allowNull
 		return &ma.ca_Previous, nil
 	default:
 		return nil, ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate.Repr", Key:&_String{k}}
@@ -11120,8 +11140,9 @@ func (ma *_RecordUpdate__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_SigPrev.m = &ma.cm
 		return &ma.ca_SigPrev
 	case 2:
-		ma.ca_Previous.w = &ma.w.Previous
-		ma.ca_Previous.m = &ma.cm
+		ma.ca_Previous.w = ma.w.Previous.v
+		ma.ca_Previous.m = &ma.w.Previous.m
+		ma.w.Previous.m = allowNull
 		return &ma.ca_Previous
 	default:
 		panic("unreachable")
@@ -11149,9 +11170,6 @@ func (ma *_RecordUpdate__ReprAssembler) Finish() error {
 		}
 		if ma.s & fieldBit__RecordUpdate_SigPrev == 0 {
 			err.Missing = append(err.Missing, "SigPrev")
-		}
-		if ma.s & fieldBit__RecordUpdate_Previous == 0 {
-			err.Missing = append(err.Missing, "Previous")
 		}
 		return err
 	}

--- a/tasks/ipldsch_satisfaction.go
+++ b/tasks/ipldsch_satisfaction.go
@@ -10244,6 +10244,9 @@ func (_PopTask__ReprKeyAssembler) Prototype() ipld.NodePrototype {
 func (n _RecordUpdate) FieldRecords() List_AuthenticatedRecord {
 	return &n.Records
 }
+func (n _RecordUpdate) FieldSigPrev() Bytes {
+	return &n.SigPrev
+}
 func (n _RecordUpdate) FieldPrevious() Link {
 	return &n.Previous
 }
@@ -10282,6 +10285,7 @@ func (m MaybeRecordUpdate) Must() RecordUpdate {
 }
 var (
 	fieldName__RecordUpdate_Records = _String{"Records"}
+	fieldName__RecordUpdate_SigPrev = _String{"SigPrev"}
 	fieldName__RecordUpdate_Previous = _String{"Previous"}
 )
 var _ ipld.Node = (RecordUpdate)(&_RecordUpdate{})
@@ -10293,6 +10297,8 @@ func (n RecordUpdate) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Records":
 		return &n.Records, nil
+	case "SigPrev":
+		return &n.SigPrev, nil
 	case "Previous":
 		return &n.Previous, nil
 	default:
@@ -10322,7 +10328,7 @@ type _RecordUpdate__MapItr struct {
 }
 
 func (itr *_RecordUpdate__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
-	if itr.idx >= 2 {
+	if itr.idx >= 3 {
 		return nil, nil, ipld.ErrIteratorOverread{}
 	}
 	switch itr.idx {
@@ -10330,6 +10336,9 @@ func (itr *_RecordUpdate__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 		k = &fieldName__RecordUpdate_Records
 		v = &itr.n.Records
 	case 1:
+		k = &fieldName__RecordUpdate_SigPrev
+		v = &itr.n.SigPrev
+	case 2:
 		k = &fieldName__RecordUpdate_Previous
 		v = &itr.n.Previous
 	default:
@@ -10339,14 +10348,14 @@ func (itr *_RecordUpdate__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 	return
 }
 func (itr *_RecordUpdate__MapItr) Done() bool {
-	return itr.idx >= 2
+	return itr.idx >= 3
 }
 
 func (RecordUpdate) ListIterator() ipld.ListIterator {
 	return nil
 }
 func (RecordUpdate) Length() int64 {
-	return 2
+	return 3
 }
 func (RecordUpdate) IsAbsent() bool {
 	return false
@@ -10405,6 +10414,7 @@ type _RecordUpdate__Assembler struct {
 
 	cm schema.Maybe
 	ca_Records _List_AuthenticatedRecord__Assembler
+	ca_SigPrev _Bytes__Assembler
 	ca_Previous _Link__Assembler
 	}
 
@@ -10412,13 +10422,15 @@ func (na *_RecordUpdate__Assembler) reset() {
 	na.state = maState_initial
 	na.s = 0
 	na.ca_Records.reset()
+	na.ca_SigPrev.reset()
 	na.ca_Previous.reset()
 }
 
 var (
 	fieldBit__RecordUpdate_Records = 1 << 0
-	fieldBit__RecordUpdate_Previous = 1 << 1
-	fieldBits__RecordUpdate_sufficient = 0 + 1 << 0 + 1 << 1
+	fieldBit__RecordUpdate_SigPrev = 1 << 1
+	fieldBit__RecordUpdate_Previous = 1 << 2
+	fieldBits__RecordUpdate_sufficient = 0 + 1 << 0 + 1 << 1 + 1 << 2
 )
 func (na *_RecordUpdate__Assembler) BeginMap(int64) (ipld.MapAssembler, error) {
 	switch *na.m {
@@ -10524,6 +10536,16 @@ func (ma *_RecordUpdate__Assembler) valueFinishTidy() bool {
 	case 1:
 		switch ma.cm {
 		case schema.Maybe_Value:
+			ma.ca_SigPrev.w = nil
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	case 2:
+		switch ma.cm {
+		case schema.Maybe_Value:
 			ma.ca_Previous.w = nil
 			ma.cm = schema.Maybe_Absent
 			ma.state = maState_initial
@@ -10561,13 +10583,23 @@ func (ma *_RecordUpdate__Assembler) AssembleEntry(k string) (ipld.NodeAssembler,
 		ma.ca_Records.w = &ma.w.Records
 		ma.ca_Records.m = &ma.cm
 		return &ma.ca_Records, nil
+	case "SigPrev":
+		if ma.s & fieldBit__RecordUpdate_SigPrev != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_SigPrev}
+		}
+		ma.s += fieldBit__RecordUpdate_SigPrev
+		ma.state = maState_midValue
+		ma.f = 1
+		ma.ca_SigPrev.w = &ma.w.SigPrev
+		ma.ca_SigPrev.m = &ma.cm
+		return &ma.ca_SigPrev, nil
 	case "Previous":
 		if ma.s & fieldBit__RecordUpdate_Previous != 0 {
 			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous}
 		}
 		ma.s += fieldBit__RecordUpdate_Previous
 		ma.state = maState_midValue
-		ma.f = 1
+		ma.f = 2
 		ma.ca_Previous.w = &ma.w.Previous
 		ma.ca_Previous.m = &ma.cm
 		return &ma.ca_Previous, nil
@@ -10613,6 +10645,10 @@ func (ma *_RecordUpdate__Assembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_Records.m = &ma.cm
 		return &ma.ca_Records
 	case 1:
+		ma.ca_SigPrev.w = &ma.w.SigPrev
+		ma.ca_SigPrev.m = &ma.cm
+		return &ma.ca_SigPrev
+	case 2:
 		ma.ca_Previous.w = &ma.w.Previous
 		ma.ca_Previous.m = &ma.cm
 		return &ma.ca_Previous
@@ -10639,6 +10675,9 @@ func (ma *_RecordUpdate__Assembler) Finish() error {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
 		if ma.s & fieldBit__RecordUpdate_Records == 0 {
 			err.Missing = append(err.Missing, "Records")
+		}
+		if ma.s & fieldBit__RecordUpdate_SigPrev == 0 {
+			err.Missing = append(err.Missing, "SigPrev")
 		}
 		if ma.s & fieldBit__RecordUpdate_Previous == 0 {
 			err.Missing = append(err.Missing, "Previous")
@@ -10686,13 +10725,20 @@ func (ka *_RecordUpdate__KeyAssembler) AssignString(k string) error {
 		ka.s += fieldBit__RecordUpdate_Records
 		ka.state = maState_expectValue
 		ka.f = 0
+	case "SigPrev":
+		if ka.s & fieldBit__RecordUpdate_SigPrev != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_SigPrev}
+		}
+		ka.s += fieldBit__RecordUpdate_SigPrev
+		ka.state = maState_expectValue
+		ka.f = 1
 	case "Previous":
 		if ka.s & fieldBit__RecordUpdate_Previous != 0 {
 			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous}
 		}
 		ka.s += fieldBit__RecordUpdate_Previous
 		ka.state = maState_expectValue
-		ka.f = 1
+		ka.f = 2
 	default:
 		return ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate", Key:&_String{k}}
 	}
@@ -10723,6 +10769,7 @@ func (n RecordUpdate) Representation() ipld.Node {
 type _RecordUpdate__Repr _RecordUpdate
 var (
 	fieldName__RecordUpdate_Records_serial = _String{"Records"}
+	fieldName__RecordUpdate_SigPrev_serial = _String{"SigPrev"}
 	fieldName__RecordUpdate_Previous_serial = _String{"Previous"}
 )
 var _ ipld.Node = &_RecordUpdate__Repr{}
@@ -10733,6 +10780,8 @@ func (n *_RecordUpdate__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Records":
 		return n.Records.Representation(), nil
+	case "SigPrev":
+		return n.SigPrev.Representation(), nil
 	case "Previous":
 		return n.Previous.Representation(), nil
 	default:
@@ -10763,7 +10812,7 @@ type _RecordUpdate__ReprMapItr struct {
 }
 
 func (itr *_RecordUpdate__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
-if itr.idx >= 2 {
+if itr.idx >= 3 {
 		return nil, nil, ipld.ErrIteratorOverread{}
 	}
 	switch itr.idx {
@@ -10771,6 +10820,9 @@ if itr.idx >= 2 {
 		k = &fieldName__RecordUpdate_Records_serial
 		v = itr.n.Records.Representation()
 	case 1:
+		k = &fieldName__RecordUpdate_SigPrev_serial
+		v = itr.n.SigPrev.Representation()
+	case 2:
 		k = &fieldName__RecordUpdate_Previous_serial
 		v = itr.n.Previous.Representation()
 	default:
@@ -10780,13 +10832,13 @@ if itr.idx >= 2 {
 	return
 }
 func (itr *_RecordUpdate__ReprMapItr) Done() bool {
-	return itr.idx >= 2
+	return itr.idx >= 3
 }
 func (_RecordUpdate__Repr) ListIterator() ipld.ListIterator {
 	return nil
 }
 func (rn *_RecordUpdate__Repr) Length() int64 {
-	l := 2
+	l := 3
 	return int64(l)
 }
 func (_RecordUpdate__Repr) IsAbsent() bool {
@@ -10846,6 +10898,7 @@ type _RecordUpdate__ReprAssembler struct {
 
 	cm schema.Maybe
 	ca_Records _List_AuthenticatedRecord__ReprAssembler
+	ca_SigPrev _Bytes__ReprAssembler
 	ca_Previous _Link__ReprAssembler
 	}
 
@@ -10853,6 +10906,7 @@ func (na *_RecordUpdate__ReprAssembler) reset() {
 	na.state = maState_initial
 	na.s = 0
 	na.ca_Records.reset()
+	na.ca_SigPrev.reset()
 	na.ca_Previous.reset()
 }
 func (na *_RecordUpdate__ReprAssembler) BeginMap(int64) (ipld.MapAssembler, error) {
@@ -10962,6 +11016,14 @@ func (ma *_RecordUpdate__ReprAssembler) valueFinishTidy() bool {
 		default:
 			return false
 		}
+	case 2:
+		switch ma.cm {
+		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
 	default:
 		panic("unreachable")
 	}
@@ -10992,13 +11054,23 @@ func (ma *_RecordUpdate__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssemb
 		ma.ca_Records.w = &ma.w.Records
 		ma.ca_Records.m = &ma.cm
 		return &ma.ca_Records, nil
+	case "SigPrev":
+		if ma.s & fieldBit__RecordUpdate_SigPrev != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_SigPrev_serial}
+		}
+		ma.s += fieldBit__RecordUpdate_SigPrev
+		ma.state = maState_midValue
+		ma.f = 1
+		ma.ca_SigPrev.w = &ma.w.SigPrev
+		ma.ca_SigPrev.m = &ma.cm
+		return &ma.ca_SigPrev, nil
 	case "Previous":
 		if ma.s & fieldBit__RecordUpdate_Previous != 0 {
 			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous_serial}
 		}
 		ma.s += fieldBit__RecordUpdate_Previous
 		ma.state = maState_midValue
-		ma.f = 1
+		ma.f = 2
 		ma.ca_Previous.w = &ma.w.Previous
 		ma.ca_Previous.m = &ma.cm
 		return &ma.ca_Previous, nil
@@ -11044,6 +11116,10 @@ func (ma *_RecordUpdate__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_Records.m = &ma.cm
 		return &ma.ca_Records
 	case 1:
+		ma.ca_SigPrev.w = &ma.w.SigPrev
+		ma.ca_SigPrev.m = &ma.cm
+		return &ma.ca_SigPrev
+	case 2:
 		ma.ca_Previous.w = &ma.w.Previous
 		ma.ca_Previous.m = &ma.cm
 		return &ma.ca_Previous
@@ -11070,6 +11146,9 @@ func (ma *_RecordUpdate__ReprAssembler) Finish() error {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
 		if ma.s & fieldBit__RecordUpdate_Records == 0 {
 			err.Missing = append(err.Missing, "Records")
+		}
+		if ma.s & fieldBit__RecordUpdate_SigPrev == 0 {
+			err.Missing = append(err.Missing, "SigPrev")
 		}
 		if ma.s & fieldBit__RecordUpdate_Previous == 0 {
 			err.Missing = append(err.Missing, "Previous")
@@ -11117,13 +11196,20 @@ func (ka *_RecordUpdate__ReprKeyAssembler) AssignString(k string) error {
 		ka.s += fieldBit__RecordUpdate_Records
 		ka.state = maState_expectValue
 		ka.f = 0
+	case "SigPrev":
+		if ka.s & fieldBit__RecordUpdate_SigPrev != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_SigPrev_serial}
+		}
+		ka.s += fieldBit__RecordUpdate_SigPrev
+		ka.state = maState_expectValue
+		ka.f = 1
 	case "Previous":
 		if ka.s & fieldBit__RecordUpdate_Previous != 0 {
 			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous_serial}
 		}
 		ka.s += fieldBit__RecordUpdate_Previous
 		ka.state = maState_expectValue
-		ka.f = 1
+		ka.f = 2
 	default:
 		return ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate.Repr", Key:&_String{k}}
 	}

--- a/tasks/ipldsch_satisfaction.go
+++ b/tasks/ipldsch_satisfaction.go
@@ -1188,6 +1188,912 @@ func (na *_Any__ReprAssembler) Prototype() ipld.NodePrototype {
 	return _Any__ReprPrototype{}
 }
 
+
+func (n _AuthenticatedRecord) FieldRecord() Link_FinishedTask {
+	return &n.Record
+}
+func (n _AuthenticatedRecord) FieldSignature() Bytes {
+	return &n.Signature
+}
+type _AuthenticatedRecord__Maybe struct {
+	m schema.Maybe
+	v AuthenticatedRecord
+}
+type MaybeAuthenticatedRecord = *_AuthenticatedRecord__Maybe
+
+func (m MaybeAuthenticatedRecord) IsNull() bool {
+	return m.m == schema.Maybe_Null
+}
+func (m MaybeAuthenticatedRecord) IsAbsent() bool {
+	return m.m == schema.Maybe_Absent
+}
+func (m MaybeAuthenticatedRecord) Exists() bool {
+	return m.m == schema.Maybe_Value
+}
+func (m MaybeAuthenticatedRecord) AsNode() ipld.Node {
+	switch m.m {
+		case schema.Maybe_Absent:
+			return ipld.Absent
+		case schema.Maybe_Null:
+			return ipld.Null
+		case schema.Maybe_Value:
+			return m.v
+		default:
+			panic("unreachable")
+	}
+}
+func (m MaybeAuthenticatedRecord) Must() AuthenticatedRecord {
+	if !m.Exists() {
+		panic("unbox of a maybe rejected")
+	}
+	return m.v
+}
+var (
+	fieldName__AuthenticatedRecord_Record = _String{"Record"}
+	fieldName__AuthenticatedRecord_Signature = _String{"Signature"}
+)
+var _ ipld.Node = (AuthenticatedRecord)(&_AuthenticatedRecord{})
+var _ schema.TypedNode = (AuthenticatedRecord)(&_AuthenticatedRecord{})
+func (AuthenticatedRecord) Kind() ipld.Kind {
+	return ipld.Kind_Map
+}
+func (n AuthenticatedRecord) LookupByString(key string) (ipld.Node, error) {
+	switch key {
+	case "Record":
+		return &n.Record, nil
+	case "Signature":
+		return &n.Signature, nil
+	default:
+		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
+	}
+}
+func (n AuthenticatedRecord) LookupByNode(key ipld.Node) (ipld.Node, error) {
+	ks, err := key.AsString()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupByString(ks)
+}
+func (AuthenticatedRecord) LookupByIndex(idx int64) (ipld.Node, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.LookupByIndex(0)
+}
+func (n AuthenticatedRecord) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
+}
+func (n AuthenticatedRecord) MapIterator() ipld.MapIterator {
+	return &_AuthenticatedRecord__MapItr{n, 0}
+}
+
+type _AuthenticatedRecord__MapItr struct {
+	n AuthenticatedRecord
+	idx  int
+}
+
+func (itr *_AuthenticatedRecord__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+	if itr.idx >= 2 {
+		return nil, nil, ipld.ErrIteratorOverread{}
+	}
+	switch itr.idx {
+	case 0:
+		k = &fieldName__AuthenticatedRecord_Record
+		v = &itr.n.Record
+	case 1:
+		k = &fieldName__AuthenticatedRecord_Signature
+		v = &itr.n.Signature
+	default:
+		panic("unreachable")
+	}
+	itr.idx++
+	return
+}
+func (itr *_AuthenticatedRecord__MapItr) Done() bool {
+	return itr.idx >= 2
+}
+
+func (AuthenticatedRecord) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (AuthenticatedRecord) Length() int64 {
+	return 2
+}
+func (AuthenticatedRecord) IsAbsent() bool {
+	return false
+}
+func (AuthenticatedRecord) IsNull() bool {
+	return false
+}
+func (AuthenticatedRecord) AsBool() (bool, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.AsBool()
+}
+func (AuthenticatedRecord) AsInt() (int64, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.AsInt()
+}
+func (AuthenticatedRecord) AsFloat() (float64, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.AsFloat()
+}
+func (AuthenticatedRecord) AsString() (string, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.AsString()
+}
+func (AuthenticatedRecord) AsBytes() ([]byte, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.AsBytes()
+}
+func (AuthenticatedRecord) AsLink() (ipld.Link, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord"}.AsLink()
+}
+func (AuthenticatedRecord) Prototype() ipld.NodePrototype {
+	return _AuthenticatedRecord__Prototype{}
+}
+type _AuthenticatedRecord__Prototype struct{}
+
+func (_AuthenticatedRecord__Prototype) NewBuilder() ipld.NodeBuilder {
+	var nb _AuthenticatedRecord__Builder
+	nb.Reset()
+	return &nb
+}
+type _AuthenticatedRecord__Builder struct {
+	_AuthenticatedRecord__Assembler
+}
+func (nb *_AuthenticatedRecord__Builder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_AuthenticatedRecord__Builder) Reset() {
+	var w _AuthenticatedRecord
+	var m schema.Maybe
+	*nb = _AuthenticatedRecord__Builder{_AuthenticatedRecord__Assembler{w: &w, m: &m}}
+}
+type _AuthenticatedRecord__Assembler struct {
+	w *_AuthenticatedRecord
+	m *schema.Maybe
+	state maState
+	s int
+	f int
+
+	cm schema.Maybe
+	ca_Record _Link_FinishedTask__Assembler
+	ca_Signature _Bytes__Assembler
+	}
+
+func (na *_AuthenticatedRecord__Assembler) reset() {
+	na.state = maState_initial
+	na.s = 0
+	na.ca_Record.reset()
+	na.ca_Signature.reset()
+}
+
+var (
+	fieldBit__AuthenticatedRecord_Record = 1 << 0
+	fieldBit__AuthenticatedRecord_Signature = 1 << 1
+	fieldBits__AuthenticatedRecord_sufficient = 0 + 1 << 0 + 1 << 1
+)
+func (na *_AuthenticatedRecord__Assembler) BeginMap(int64) (ipld.MapAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if na.w == nil {
+		na.w = &_AuthenticatedRecord{}
+	}
+	return na, nil
+}
+func (_AuthenticatedRecord__Assembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.BeginList(0)
+}
+func (na *_AuthenticatedRecord__Assembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_AuthenticatedRecord__Assembler) AssignBool(bool) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignBool(false)
+}
+func (_AuthenticatedRecord__Assembler) AssignInt(int64) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignInt(0)
+}
+func (_AuthenticatedRecord__Assembler) AssignFloat(float64) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignFloat(0)
+}
+func (_AuthenticatedRecord__Assembler) AssignString(string) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignString("")
+}
+func (_AuthenticatedRecord__Assembler) AssignBytes([]byte) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignBytes(nil)
+}
+func (_AuthenticatedRecord__Assembler) AssignLink(ipld.Link) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord"}.AssignLink(nil)
+}
+func (na *_AuthenticatedRecord__Assembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_AuthenticatedRecord); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != ipld.Kind_Map {
+		return ipld.ErrWrongKind{TypeName: "tasks.AuthenticatedRecord", MethodName: "AssignNode", AppropriateKind: ipld.KindSet_JustMap, ActualKind: v.Kind()}
+	}
+	itr := v.MapIterator()
+	for !itr.Done() {
+		k, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleKey().AssignNode(k); err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_AuthenticatedRecord__Assembler) Prototype() ipld.NodePrototype {
+	return _AuthenticatedRecord__Prototype{}
+}
+func (ma *_AuthenticatedRecord__Assembler) valueFinishTidy() bool {
+	switch ma.f {
+	case 0:
+		switch ma.cm {
+		case schema.Maybe_Value:
+			ma.ca_Record.w = nil
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	case 1:
+		switch ma.cm {
+		case schema.Maybe_Value:
+			ma.ca_Signature.w = nil
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_AuthenticatedRecord__Assembler) AssembleEntry(k string) (ipld.NodeAssembler, error) {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleEntry cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleEntry cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleEntry cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleEntry cannot be called on an assembler that's already finished")
+	}
+	switch k {
+	case "Record":
+		if ma.s & fieldBit__AuthenticatedRecord_Record != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Record}
+		}
+		ma.s += fieldBit__AuthenticatedRecord_Record
+		ma.state = maState_midValue
+		ma.f = 0
+		ma.ca_Record.w = &ma.w.Record
+		ma.ca_Record.m = &ma.cm
+		return &ma.ca_Record, nil
+	case "Signature":
+		if ma.s & fieldBit__AuthenticatedRecord_Signature != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Signature}
+		}
+		ma.s += fieldBit__AuthenticatedRecord_Signature
+		ma.state = maState_midValue
+		ma.f = 1
+		ma.ca_Signature.w = &ma.w.Signature
+		ma.ca_Signature.m = &ma.cm
+		return &ma.ca_Signature, nil
+	default:
+		return nil, ipld.ErrInvalidKey{TypeName:"tasks.AuthenticatedRecord", Key:&_String{k}}
+	}
+}
+func (ma *_AuthenticatedRecord__Assembler) AssembleKey() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleKey cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleKey cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleKey cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleKey cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midKey
+	return (*_AuthenticatedRecord__KeyAssembler)(ma)
+}
+func (ma *_AuthenticatedRecord__Assembler) AssembleValue() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		panic("invalid state: AssembleValue cannot be called when no key is primed")
+	case maState_midKey:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		// carry on
+	case maState_midValue:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling another value")
+	case maState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midValue
+	switch ma.f {
+	case 0:
+		ma.ca_Record.w = &ma.w.Record
+		ma.ca_Record.m = &ma.cm
+		return &ma.ca_Record
+	case 1:
+		ma.ca_Signature.w = &ma.w.Signature
+		ma.ca_Signature.m = &ma.cm
+		return &ma.ca_Signature
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_AuthenticatedRecord__Assembler) Finish() error {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: Finish cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		panic("invalid state: Finish cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	if ma.s & fieldBits__AuthenticatedRecord_sufficient != fieldBits__AuthenticatedRecord_sufficient {
+		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
+		if ma.s & fieldBit__AuthenticatedRecord_Record == 0 {
+			err.Missing = append(err.Missing, "Record")
+		}
+		if ma.s & fieldBit__AuthenticatedRecord_Signature == 0 {
+			err.Missing = append(err.Missing, "Signature")
+		}
+		return err
+	}
+	ma.state = maState_finished
+	*ma.m = schema.Maybe_Value
+	return nil
+}
+func (ma *_AuthenticatedRecord__Assembler) KeyPrototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+func (ma *_AuthenticatedRecord__Assembler) ValuePrototype(k string) ipld.NodePrototype {
+	panic("todo structbuilder mapassembler valueprototype")
+}
+type _AuthenticatedRecord__KeyAssembler _AuthenticatedRecord__Assembler
+func (_AuthenticatedRecord__KeyAssembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.BeginMap(0)
+}
+func (_AuthenticatedRecord__KeyAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.BeginList(0)
+}
+func (na *_AuthenticatedRecord__KeyAssembler) AssignNull() error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.AssignNull()
+}
+func (_AuthenticatedRecord__KeyAssembler) AssignBool(bool) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.AssignBool(false)
+}
+func (_AuthenticatedRecord__KeyAssembler) AssignInt(int64) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.AssignInt(0)
+}
+func (_AuthenticatedRecord__KeyAssembler) AssignFloat(float64) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.AssignFloat(0)
+}
+func (ka *_AuthenticatedRecord__KeyAssembler) AssignString(k string) error {
+	if ka.state != maState_midKey {
+		panic("misuse: KeyAssembler held beyond its valid lifetime")
+	}
+	switch k {
+	case "Record":
+		if ka.s & fieldBit__AuthenticatedRecord_Record != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Record}
+		}
+		ka.s += fieldBit__AuthenticatedRecord_Record
+		ka.state = maState_expectValue
+		ka.f = 0
+	case "Signature":
+		if ka.s & fieldBit__AuthenticatedRecord_Signature != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Signature}
+		}
+		ka.s += fieldBit__AuthenticatedRecord_Signature
+		ka.state = maState_expectValue
+		ka.f = 1
+	default:
+		return ipld.ErrInvalidKey{TypeName:"tasks.AuthenticatedRecord", Key:&_String{k}}
+	}
+	return nil
+}
+func (_AuthenticatedRecord__KeyAssembler) AssignBytes([]byte) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.AssignBytes(nil)
+}
+func (_AuthenticatedRecord__KeyAssembler) AssignLink(ipld.Link) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.KeyAssembler"}.AssignLink(nil)
+}
+func (ka *_AuthenticatedRecord__KeyAssembler) AssignNode(v ipld.Node) error {
+	if v2, err := v.AsString(); err != nil {
+		return err
+	} else {
+		return ka.AssignString(v2)
+	}
+}
+func (_AuthenticatedRecord__KeyAssembler) Prototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+func (AuthenticatedRecord) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (n AuthenticatedRecord) Representation() ipld.Node {
+	return (*_AuthenticatedRecord__Repr)(n)
+}
+type _AuthenticatedRecord__Repr _AuthenticatedRecord
+var (
+	fieldName__AuthenticatedRecord_Record_serial = _String{"Record"}
+	fieldName__AuthenticatedRecord_Signature_serial = _String{"Signature"}
+)
+var _ ipld.Node = &_AuthenticatedRecord__Repr{}
+func (_AuthenticatedRecord__Repr) Kind() ipld.Kind {
+	return ipld.Kind_Map
+}
+func (n *_AuthenticatedRecord__Repr) LookupByString(key string) (ipld.Node, error) {
+	switch key {
+	case "Record":
+		return n.Record.Representation(), nil
+	case "Signature":
+		return n.Signature.Representation(), nil
+	default:
+		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
+	}
+}
+func (n *_AuthenticatedRecord__Repr) LookupByNode(key ipld.Node) (ipld.Node, error) {
+	ks, err := key.AsString()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupByString(ks)
+}
+func (_AuthenticatedRecord__Repr) LookupByIndex(idx int64) (ipld.Node, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.LookupByIndex(0)
+}
+func (n _AuthenticatedRecord__Repr) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
+}
+func (n *_AuthenticatedRecord__Repr) MapIterator() ipld.MapIterator {
+	return &_AuthenticatedRecord__ReprMapItr{n, 0}
+}
+
+type _AuthenticatedRecord__ReprMapItr struct {
+	n   *_AuthenticatedRecord__Repr
+	idx int
+	
+}
+
+func (itr *_AuthenticatedRecord__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+if itr.idx >= 2 {
+		return nil, nil, ipld.ErrIteratorOverread{}
+	}
+	switch itr.idx {
+	case 0:
+		k = &fieldName__AuthenticatedRecord_Record_serial
+		v = itr.n.Record.Representation()
+	case 1:
+		k = &fieldName__AuthenticatedRecord_Signature_serial
+		v = itr.n.Signature.Representation()
+	default:
+		panic("unreachable")
+	}
+	itr.idx++
+	return
+}
+func (itr *_AuthenticatedRecord__ReprMapItr) Done() bool {
+	return itr.idx >= 2
+}
+func (_AuthenticatedRecord__Repr) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (rn *_AuthenticatedRecord__Repr) Length() int64 {
+	l := 2
+	return int64(l)
+}
+func (_AuthenticatedRecord__Repr) IsAbsent() bool {
+	return false
+}
+func (_AuthenticatedRecord__Repr) IsNull() bool {
+	return false
+}
+func (_AuthenticatedRecord__Repr) AsBool() (bool, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.AsBool()
+}
+func (_AuthenticatedRecord__Repr) AsInt() (int64, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.AsInt()
+}
+func (_AuthenticatedRecord__Repr) AsFloat() (float64, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.AsFloat()
+}
+func (_AuthenticatedRecord__Repr) AsString() (string, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.AsString()
+}
+func (_AuthenticatedRecord__Repr) AsBytes() ([]byte, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.AsBytes()
+}
+func (_AuthenticatedRecord__Repr) AsLink() (ipld.Link, error) {
+	return mixins.Map{"tasks.AuthenticatedRecord.Repr"}.AsLink()
+}
+func (_AuthenticatedRecord__Repr) Prototype() ipld.NodePrototype {
+	return _AuthenticatedRecord__ReprPrototype{}
+}
+type _AuthenticatedRecord__ReprPrototype struct{}
+
+func (_AuthenticatedRecord__ReprPrototype) NewBuilder() ipld.NodeBuilder {
+	var nb _AuthenticatedRecord__ReprBuilder
+	nb.Reset()
+	return &nb
+}
+type _AuthenticatedRecord__ReprBuilder struct {
+	_AuthenticatedRecord__ReprAssembler
+}
+func (nb *_AuthenticatedRecord__ReprBuilder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_AuthenticatedRecord__ReprBuilder) Reset() {
+	var w _AuthenticatedRecord
+	var m schema.Maybe
+	*nb = _AuthenticatedRecord__ReprBuilder{_AuthenticatedRecord__ReprAssembler{w: &w, m: &m}}
+}
+type _AuthenticatedRecord__ReprAssembler struct {
+	w *_AuthenticatedRecord
+	m *schema.Maybe
+	state maState
+	s int
+	f int
+
+	cm schema.Maybe
+	ca_Record _Link_FinishedTask__ReprAssembler
+	ca_Signature _Bytes__ReprAssembler
+	}
+
+func (na *_AuthenticatedRecord__ReprAssembler) reset() {
+	na.state = maState_initial
+	na.s = 0
+	na.ca_Record.reset()
+	na.ca_Signature.reset()
+}
+func (na *_AuthenticatedRecord__ReprAssembler) BeginMap(int64) (ipld.MapAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if na.w == nil {
+		na.w = &_AuthenticatedRecord{}
+	}
+	return na, nil
+}
+func (_AuthenticatedRecord__ReprAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.BeginList(0)
+}
+func (na *_AuthenticatedRecord__ReprAssembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr.Repr"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_AuthenticatedRecord__ReprAssembler) AssignBool(bool) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.AssignBool(false)
+}
+func (_AuthenticatedRecord__ReprAssembler) AssignInt(int64) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.AssignInt(0)
+}
+func (_AuthenticatedRecord__ReprAssembler) AssignFloat(float64) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.AssignFloat(0)
+}
+func (_AuthenticatedRecord__ReprAssembler) AssignString(string) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.AssignString("")
+}
+func (_AuthenticatedRecord__ReprAssembler) AssignBytes([]byte) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.AssignBytes(nil)
+}
+func (_AuthenticatedRecord__ReprAssembler) AssignLink(ipld.Link) error {
+	return mixins.MapAssembler{"tasks.AuthenticatedRecord.Repr"}.AssignLink(nil)
+}
+func (na *_AuthenticatedRecord__ReprAssembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_AuthenticatedRecord); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != ipld.Kind_Map {
+		return ipld.ErrWrongKind{TypeName: "tasks.AuthenticatedRecord.Repr", MethodName: "AssignNode", AppropriateKind: ipld.KindSet_JustMap, ActualKind: v.Kind()}
+	}
+	itr := v.MapIterator()
+	for !itr.Done() {
+		k, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleKey().AssignNode(k); err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_AuthenticatedRecord__ReprAssembler) Prototype() ipld.NodePrototype {
+	return _AuthenticatedRecord__ReprPrototype{}
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) valueFinishTidy() bool {
+	switch ma.f {
+	case 0:
+		switch ma.cm {
+		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	case 1:
+		switch ma.cm {
+		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssembler, error) {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleEntry cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleEntry cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleEntry cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleEntry cannot be called on an assembler that's already finished")
+	}
+	switch k {
+	case "Record":
+		if ma.s & fieldBit__AuthenticatedRecord_Record != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Record_serial}
+		}
+		ma.s += fieldBit__AuthenticatedRecord_Record
+		ma.state = maState_midValue
+		ma.f = 0
+		ma.ca_Record.w = &ma.w.Record
+		ma.ca_Record.m = &ma.cm
+		return &ma.ca_Record, nil
+	case "Signature":
+		if ma.s & fieldBit__AuthenticatedRecord_Signature != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Signature_serial}
+		}
+		ma.s += fieldBit__AuthenticatedRecord_Signature
+		ma.state = maState_midValue
+		ma.f = 1
+		ma.ca_Signature.w = &ma.w.Signature
+		ma.ca_Signature.m = &ma.cm
+		return &ma.ca_Signature, nil
+	default:
+		return nil, ipld.ErrInvalidKey{TypeName:"tasks.AuthenticatedRecord.Repr", Key:&_String{k}}
+	}
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) AssembleKey() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleKey cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleKey cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleKey cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleKey cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midKey
+	return (*_AuthenticatedRecord__ReprKeyAssembler)(ma)
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) AssembleValue() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		panic("invalid state: AssembleValue cannot be called when no key is primed")
+	case maState_midKey:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		// carry on
+	case maState_midValue:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling another value")
+	case maState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midValue
+	switch ma.f {
+	case 0:
+		ma.ca_Record.w = &ma.w.Record
+		ma.ca_Record.m = &ma.cm
+		return &ma.ca_Record
+	case 1:
+		ma.ca_Signature.w = &ma.w.Signature
+		ma.ca_Signature.m = &ma.cm
+		return &ma.ca_Signature
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) Finish() error {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: Finish cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		panic("invalid state: Finish cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	if ma.s & fieldBits__AuthenticatedRecord_sufficient != fieldBits__AuthenticatedRecord_sufficient {
+		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
+		if ma.s & fieldBit__AuthenticatedRecord_Record == 0 {
+			err.Missing = append(err.Missing, "Record")
+		}
+		if ma.s & fieldBit__AuthenticatedRecord_Signature == 0 {
+			err.Missing = append(err.Missing, "Signature")
+		}
+		return err
+	}
+	ma.state = maState_finished
+	*ma.m = schema.Maybe_Value
+	return nil
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) KeyPrototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+func (ma *_AuthenticatedRecord__ReprAssembler) ValuePrototype(k string) ipld.NodePrototype {
+	panic("todo structbuilder mapassembler repr valueprototype")
+}
+type _AuthenticatedRecord__ReprKeyAssembler _AuthenticatedRecord__ReprAssembler
+func (_AuthenticatedRecord__ReprKeyAssembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.BeginMap(0)
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.BeginList(0)
+}
+func (na *_AuthenticatedRecord__ReprKeyAssembler) AssignNull() error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.AssignNull()
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) AssignBool(bool) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.AssignBool(false)
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) AssignInt(int64) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.AssignInt(0)
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) AssignFloat(float64) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.AssignFloat(0)
+}
+func (ka *_AuthenticatedRecord__ReprKeyAssembler) AssignString(k string) error {
+	if ka.state != maState_midKey {
+		panic("misuse: KeyAssembler held beyond its valid lifetime")
+	}
+	switch k {
+	case "Record":
+		if ka.s & fieldBit__AuthenticatedRecord_Record != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Record_serial}
+		}
+		ka.s += fieldBit__AuthenticatedRecord_Record
+		ka.state = maState_expectValue
+		ka.f = 0
+	case "Signature":
+		if ka.s & fieldBit__AuthenticatedRecord_Signature != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__AuthenticatedRecord_Signature_serial}
+		}
+		ka.s += fieldBit__AuthenticatedRecord_Signature
+		ka.state = maState_expectValue
+		ka.f = 1
+	default:
+		return ipld.ErrInvalidKey{TypeName:"tasks.AuthenticatedRecord.Repr", Key:&_String{k}}
+	}
+	return nil
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) AssignBytes([]byte) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.AssignBytes(nil)
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) AssignLink(ipld.Link) error {
+	return mixins.StringAssembler{"tasks.AuthenticatedRecord.Repr.KeyAssembler"}.AssignLink(nil)
+}
+func (ka *_AuthenticatedRecord__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+	if v2, err := v.AsString(); err != nil {
+		return err
+	} else {
+		return ka.AssignString(v2)
+	}
+}
+func (_AuthenticatedRecord__ReprKeyAssembler) Prototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+
 func (n Bool) Bool() bool {
 	return n.x
 }
@@ -3948,6 +4854,212 @@ var _ ipld.Node = &_Link__Repr{}
 type _Link__ReprPrototype = _Link__Prototype
 type _Link__ReprAssembler = _Link__Assembler
 
+func (n Link_FinishedTask) Link() ipld.Link {
+	return n.x
+}
+func (_Link_FinishedTask__Prototype) FromLink(v ipld.Link) (Link_FinishedTask, error) {
+	n := _Link_FinishedTask{v}
+	return &n, nil
+}
+type _Link_FinishedTask__Maybe struct {
+	m schema.Maybe
+	v Link_FinishedTask
+}
+type MaybeLink_FinishedTask = *_Link_FinishedTask__Maybe
+
+func (m MaybeLink_FinishedTask) IsNull() bool {
+	return m.m == schema.Maybe_Null
+}
+func (m MaybeLink_FinishedTask) IsAbsent() bool {
+	return m.m == schema.Maybe_Absent
+}
+func (m MaybeLink_FinishedTask) Exists() bool {
+	return m.m == schema.Maybe_Value
+}
+func (m MaybeLink_FinishedTask) AsNode() ipld.Node {
+	switch m.m {
+		case schema.Maybe_Absent:
+			return ipld.Absent
+		case schema.Maybe_Null:
+			return ipld.Null
+		case schema.Maybe_Value:
+			return m.v
+		default:
+			panic("unreachable")
+	}
+}
+func (m MaybeLink_FinishedTask) Must() Link_FinishedTask {
+	if !m.Exists() {
+		panic("unbox of a maybe rejected")
+	}
+	return m.v
+}
+var _ ipld.Node = (Link_FinishedTask)(&_Link_FinishedTask{})
+var _ schema.TypedNode = (Link_FinishedTask)(&_Link_FinishedTask{})
+func (Link_FinishedTask) Kind() ipld.Kind {
+	return ipld.Kind_Link
+}
+func (Link_FinishedTask) LookupByString(string) (ipld.Node, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.LookupByString("")
+}
+func (Link_FinishedTask) LookupByNode(ipld.Node) (ipld.Node, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.LookupByNode(nil)
+}
+func (Link_FinishedTask) LookupByIndex(idx int64) (ipld.Node, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.LookupByIndex(0)
+}
+func (Link_FinishedTask) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.LookupBySegment(seg)
+}
+func (Link_FinishedTask) MapIterator() ipld.MapIterator {
+	return nil
+}
+func (Link_FinishedTask) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (Link_FinishedTask) Length() int64 {
+	return -1
+}
+func (Link_FinishedTask) IsAbsent() bool {
+	return false
+}
+func (Link_FinishedTask) IsNull() bool {
+	return false
+}
+func (Link_FinishedTask) AsBool() (bool, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.AsBool()
+}
+func (Link_FinishedTask) AsInt() (int64, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.AsInt()
+}
+func (Link_FinishedTask) AsFloat() (float64, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.AsFloat()
+}
+func (Link_FinishedTask) AsString() (string, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.AsString()
+}
+func (Link_FinishedTask) AsBytes() ([]byte, error) {
+	return mixins.Link{"tasks.Link_FinishedTask"}.AsBytes()
+}
+func (n Link_FinishedTask) AsLink() (ipld.Link, error) {
+	return n.x, nil
+}
+func (Link_FinishedTask) Prototype() ipld.NodePrototype {
+	return _Link_FinishedTask__Prototype{}
+}
+type _Link_FinishedTask__Prototype struct{}
+
+func (_Link_FinishedTask__Prototype) NewBuilder() ipld.NodeBuilder {
+	var nb _Link_FinishedTask__Builder
+	nb.Reset()
+	return &nb
+}
+type _Link_FinishedTask__Builder struct {
+	_Link_FinishedTask__Assembler
+}
+func (nb *_Link_FinishedTask__Builder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_Link_FinishedTask__Builder) Reset() {
+	var w _Link_FinishedTask
+	var m schema.Maybe
+	*nb = _Link_FinishedTask__Builder{_Link_FinishedTask__Assembler{w: &w, m: &m}}
+}
+type _Link_FinishedTask__Assembler struct {
+	w *_Link_FinishedTask
+	m *schema.Maybe
+}
+
+func (na *_Link_FinishedTask__Assembler) reset() {}
+func (_Link_FinishedTask__Assembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.BeginMap(0)
+}
+func (_Link_FinishedTask__Assembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.BeginList(0)
+}
+func (na *_Link_FinishedTask__Assembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	}
+	panic("unreachable")
+}
+func (_Link_FinishedTask__Assembler) AssignBool(bool) error {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.AssignBool(false)
+}
+func (_Link_FinishedTask__Assembler) AssignInt(int64) error {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.AssignInt(0)
+}
+func (_Link_FinishedTask__Assembler) AssignFloat(float64) error {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.AssignFloat(0)
+}
+func (_Link_FinishedTask__Assembler) AssignString(string) error {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.AssignString("")
+}
+func (_Link_FinishedTask__Assembler) AssignBytes([]byte) error {
+	return mixins.LinkAssembler{"tasks.Link_FinishedTask"}.AssignBytes(nil)
+}
+func (na *_Link_FinishedTask__Assembler) AssignLink(v ipld.Link) error {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	}
+	if na.w == nil {
+		na.w = &_Link_FinishedTask{}
+	}
+	na.w.x = v
+	*na.m = schema.Maybe_Value
+	return nil
+}
+func (na *_Link_FinishedTask__Assembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_Link_FinishedTask); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v2, err := v.AsLink(); err != nil {
+		return err
+	} else {
+		return na.AssignLink(v2)
+	}
+}
+func (_Link_FinishedTask__Assembler) Prototype() ipld.NodePrototype {
+	return _Link_FinishedTask__Prototype{}
+}
+func (Link_FinishedTask) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (Link_FinishedTask) LinkTargetNodePrototype() ipld.NodePrototype {
+	return Type.Link_FinishedTask__Repr
+}
+func (n Link_FinishedTask) Representation() ipld.Node {
+	return (*_Link_FinishedTask__Repr)(n)
+}
+type _Link_FinishedTask__Repr = _Link_FinishedTask
+var _ ipld.Node = &_Link_FinishedTask__Repr{}
+type _Link_FinishedTask__ReprPrototype = _Link_FinishedTask__Prototype
+type _Link_FinishedTask__ReprAssembler = _Link_FinishedTask__Assembler
+
 func (n Link_List_StageDetails) Link() ipld.Link {
 	return n.x
 }
@@ -4759,6 +5871,599 @@ func (la *_List__ReprAssembler) Finish() error {
 }
 func (la *_List__ReprAssembler) ValuePrototype(_ int64) ipld.NodePrototype {
 	return _Any__ReprPrototype{}
+}
+
+func (n *_List_AuthenticatedRecord) Lookup(idx int64) AuthenticatedRecord {
+	if n.Length() <= idx {
+		return nil
+	}
+	v := &n.x[idx]
+	return v
+}
+func (n *_List_AuthenticatedRecord) LookupMaybe(idx int64) MaybeAuthenticatedRecord {
+	if n.Length() <= idx {
+		return nil
+	}
+	v := &n.x[idx]
+	return &_AuthenticatedRecord__Maybe{
+		m: schema.Maybe_Value,
+		v: v,
+	}
+}
+
+var _List_AuthenticatedRecord__valueAbsent = _AuthenticatedRecord__Maybe{m:schema.Maybe_Absent}
+func (n List_AuthenticatedRecord) Iterator() *List_AuthenticatedRecord__Itr {
+	return &List_AuthenticatedRecord__Itr{n, 0}
+}
+
+type List_AuthenticatedRecord__Itr struct {
+	n List_AuthenticatedRecord
+	idx  int
+}
+
+func (itr *List_AuthenticatedRecord__Itr) Next() (idx int64, v AuthenticatedRecord) {
+	if itr.idx >= len(itr.n.x) {
+		return -1, nil
+	}
+	idx = int64(itr.idx)
+	v = &itr.n.x[itr.idx]
+	itr.idx++
+	return
+}
+func (itr *List_AuthenticatedRecord__Itr) Done() bool {
+	return itr.idx >= len(itr.n.x)
+}
+
+type _List_AuthenticatedRecord__Maybe struct {
+	m schema.Maybe
+	v List_AuthenticatedRecord
+}
+type MaybeList_AuthenticatedRecord = *_List_AuthenticatedRecord__Maybe
+
+func (m MaybeList_AuthenticatedRecord) IsNull() bool {
+	return m.m == schema.Maybe_Null
+}
+func (m MaybeList_AuthenticatedRecord) IsAbsent() bool {
+	return m.m == schema.Maybe_Absent
+}
+func (m MaybeList_AuthenticatedRecord) Exists() bool {
+	return m.m == schema.Maybe_Value
+}
+func (m MaybeList_AuthenticatedRecord) AsNode() ipld.Node {
+	switch m.m {
+		case schema.Maybe_Absent:
+			return ipld.Absent
+		case schema.Maybe_Null:
+			return ipld.Null
+		case schema.Maybe_Value:
+			return m.v
+		default:
+			panic("unreachable")
+	}
+}
+func (m MaybeList_AuthenticatedRecord) Must() List_AuthenticatedRecord {
+	if !m.Exists() {
+		panic("unbox of a maybe rejected")
+	}
+	return m.v
+}
+var _ ipld.Node = (List_AuthenticatedRecord)(&_List_AuthenticatedRecord{})
+var _ schema.TypedNode = (List_AuthenticatedRecord)(&_List_AuthenticatedRecord{})
+func (List_AuthenticatedRecord) Kind() ipld.Kind {
+	return ipld.Kind_List
+}
+func (List_AuthenticatedRecord) LookupByString(string) (ipld.Node, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.LookupByString("")
+}
+func (n List_AuthenticatedRecord) LookupByNode(k ipld.Node) (ipld.Node, error) {
+	idx, err := k.AsInt()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupByIndex(idx)
+}
+func (n List_AuthenticatedRecord) LookupByIndex(idx int64) (ipld.Node, error) {
+	if n.Length() <= idx {
+		return nil, ipld.ErrNotExists{ipld.PathSegmentOfInt(idx)}
+	}
+	v := &n.x[idx]
+	return v, nil
+}
+func (n List_AuthenticatedRecord) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	i, err := seg.Index()
+	if err != nil {
+		return nil, ipld.ErrInvalidSegmentForList{TypeName: "tasks.List_AuthenticatedRecord", TroubleSegment: seg, Reason: err}
+	}
+	return n.LookupByIndex(i)
+}
+func (List_AuthenticatedRecord) MapIterator() ipld.MapIterator {
+	return nil
+}
+func (n List_AuthenticatedRecord) ListIterator() ipld.ListIterator {
+	return &_List_AuthenticatedRecord__ListItr{n, 0}
+}
+
+type _List_AuthenticatedRecord__ListItr struct {
+	n List_AuthenticatedRecord
+	idx  int
+}
+
+func (itr *_List_AuthenticatedRecord__ListItr) Next() (idx int64, v ipld.Node, _ error) {
+	if itr.idx >= len(itr.n.x) {
+		return -1, nil, ipld.ErrIteratorOverread{}
+	}
+	idx = int64(itr.idx)
+	x := &itr.n.x[itr.idx]
+	v = x
+	itr.idx++
+	return
+}
+func (itr *_List_AuthenticatedRecord__ListItr) Done() bool {
+	return itr.idx >= len(itr.n.x)
+}
+
+func (n List_AuthenticatedRecord) Length() int64 {
+	return int64(len(n.x))
+}
+func (List_AuthenticatedRecord) IsAbsent() bool {
+	return false
+}
+func (List_AuthenticatedRecord) IsNull() bool {
+	return false
+}
+func (List_AuthenticatedRecord) AsBool() (bool, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.AsBool()
+}
+func (List_AuthenticatedRecord) AsInt() (int64, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.AsInt()
+}
+func (List_AuthenticatedRecord) AsFloat() (float64, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.AsFloat()
+}
+func (List_AuthenticatedRecord) AsString() (string, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.AsString()
+}
+func (List_AuthenticatedRecord) AsBytes() ([]byte, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.AsBytes()
+}
+func (List_AuthenticatedRecord) AsLink() (ipld.Link, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord"}.AsLink()
+}
+func (List_AuthenticatedRecord) Prototype() ipld.NodePrototype {
+	return _List_AuthenticatedRecord__Prototype{}
+}
+type _List_AuthenticatedRecord__Prototype struct{}
+
+func (_List_AuthenticatedRecord__Prototype) NewBuilder() ipld.NodeBuilder {
+	var nb _List_AuthenticatedRecord__Builder
+	nb.Reset()
+	return &nb
+}
+type _List_AuthenticatedRecord__Builder struct {
+	_List_AuthenticatedRecord__Assembler
+}
+func (nb *_List_AuthenticatedRecord__Builder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_List_AuthenticatedRecord__Builder) Reset() {
+	var w _List_AuthenticatedRecord
+	var m schema.Maybe
+	*nb = _List_AuthenticatedRecord__Builder{_List_AuthenticatedRecord__Assembler{w: &w, m: &m}}
+}
+type _List_AuthenticatedRecord__Assembler struct {
+	w *_List_AuthenticatedRecord
+	m *schema.Maybe
+	state laState
+
+	cm schema.Maybe
+	va _AuthenticatedRecord__Assembler
+}
+
+func (na *_List_AuthenticatedRecord__Assembler) reset() {
+	na.state = laState_initial
+	na.va.reset()
+}
+func (_List_AuthenticatedRecord__Assembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.BeginMap(0)
+}
+func (na *_List_AuthenticatedRecord__Assembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	if na.w == nil {
+		na.w = &_List_AuthenticatedRecord{}
+	}
+	if sizeHint > 0 {
+		na.w.x = make([]_AuthenticatedRecord, 0, sizeHint)
+	}
+	return na, nil
+}
+func (na *_List_AuthenticatedRecord__Assembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_List_AuthenticatedRecord__Assembler) AssignBool(bool) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignBool(false)
+}
+func (_List_AuthenticatedRecord__Assembler) AssignInt(int64) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignInt(0)
+}
+func (_List_AuthenticatedRecord__Assembler) AssignFloat(float64) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignFloat(0)
+}
+func (_List_AuthenticatedRecord__Assembler) AssignString(string) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignString("")
+}
+func (_List_AuthenticatedRecord__Assembler) AssignBytes([]byte) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignBytes(nil)
+}
+func (_List_AuthenticatedRecord__Assembler) AssignLink(ipld.Link) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord"}.AssignLink(nil)
+}
+func (na *_List_AuthenticatedRecord__Assembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_List_AuthenticatedRecord); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != ipld.Kind_List {
+		return ipld.ErrWrongKind{TypeName: "tasks.List_AuthenticatedRecord", MethodName: "AssignNode", AppropriateKind: ipld.KindSet_JustList, ActualKind: v.Kind()}
+	}
+	itr := v.ListIterator()
+	for !itr.Done() {
+		_, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_List_AuthenticatedRecord__Assembler) Prototype() ipld.NodePrototype {
+	return _List_AuthenticatedRecord__Prototype{}
+}
+func (la *_List_AuthenticatedRecord__Assembler) valueFinishTidy() bool {
+	switch la.cm {
+	case schema.Maybe_Value:
+		la.va.w = nil
+		la.cm = schema.Maybe_Absent
+		la.state = laState_initial
+		la.va.reset()
+		return true
+	default:
+		return false
+	}
+}
+func (la *_List_AuthenticatedRecord__Assembler) AssembleValue() ipld.NodeAssembler {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: AssembleValue cannot be called when still in the middle of assembling the previous value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	la.w.x = append(la.w.x, _AuthenticatedRecord{})
+	la.state = laState_midValue
+	row := &la.w.x[len(la.w.x)-1]
+	la.va.w = row
+	la.va.m = &la.cm
+	return &la.va
+}
+func (la *_List_AuthenticatedRecord__Assembler) Finish() error {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	la.state = laState_finished
+	*la.m = schema.Maybe_Value
+	return nil
+}
+func (la *_List_AuthenticatedRecord__Assembler) ValuePrototype(_ int64) ipld.NodePrototype {
+	return _AuthenticatedRecord__Prototype{}
+}
+func (List_AuthenticatedRecord) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (n List_AuthenticatedRecord) Representation() ipld.Node {
+	return (*_List_AuthenticatedRecord__Repr)(n)
+}
+type _List_AuthenticatedRecord__Repr _List_AuthenticatedRecord
+var _ ipld.Node = &_List_AuthenticatedRecord__Repr{}
+func (_List_AuthenticatedRecord__Repr) Kind() ipld.Kind {
+	return ipld.Kind_List
+}
+func (_List_AuthenticatedRecord__Repr) LookupByString(string) (ipld.Node, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.LookupByString("")
+}
+func (nr *_List_AuthenticatedRecord__Repr) LookupByNode(k ipld.Node) (ipld.Node, error) {
+	v, err := (List_AuthenticatedRecord)(nr).LookupByNode(k)
+	if err != nil || v == ipld.Null {
+		return v, err
+	}
+	return v.(AuthenticatedRecord).Representation(), nil
+}
+func (nr *_List_AuthenticatedRecord__Repr) LookupByIndex(idx int64) (ipld.Node, error) {
+	v, err := (List_AuthenticatedRecord)(nr).LookupByIndex(idx)
+	if err != nil || v == ipld.Null {
+		return v, err
+	}
+	return v.(AuthenticatedRecord).Representation(), nil
+}
+func (n _List_AuthenticatedRecord__Repr) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	i, err := seg.Index()
+	if err != nil {
+		return nil, ipld.ErrInvalidSegmentForList{TypeName: "tasks.List_AuthenticatedRecord.Repr", TroubleSegment: seg, Reason: err}
+	}
+	return n.LookupByIndex(i)
+}
+func (_List_AuthenticatedRecord__Repr) MapIterator() ipld.MapIterator {
+	return nil
+}
+func (nr *_List_AuthenticatedRecord__Repr) ListIterator() ipld.ListIterator {
+	return &_List_AuthenticatedRecord__ReprListItr{(List_AuthenticatedRecord)(nr), 0}
+}
+
+type _List_AuthenticatedRecord__ReprListItr _List_AuthenticatedRecord__ListItr
+
+func (itr *_List_AuthenticatedRecord__ReprListItr) Next() (idx int64, v ipld.Node, err error) {
+	idx, v, err = (*_List_AuthenticatedRecord__ListItr)(itr).Next()
+	if err != nil || v == ipld.Null {
+		return
+	}
+	return idx, v.(AuthenticatedRecord).Representation(), nil
+}
+func (itr *_List_AuthenticatedRecord__ReprListItr) Done() bool {
+	return (*_List_AuthenticatedRecord__ListItr)(itr).Done()
+}
+
+func (rn *_List_AuthenticatedRecord__Repr) Length() int64 {
+	return int64(len(rn.x))
+}
+func (_List_AuthenticatedRecord__Repr) IsAbsent() bool {
+	return false
+}
+func (_List_AuthenticatedRecord__Repr) IsNull() bool {
+	return false
+}
+func (_List_AuthenticatedRecord__Repr) AsBool() (bool, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.AsBool()
+}
+func (_List_AuthenticatedRecord__Repr) AsInt() (int64, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.AsInt()
+}
+func (_List_AuthenticatedRecord__Repr) AsFloat() (float64, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.AsFloat()
+}
+func (_List_AuthenticatedRecord__Repr) AsString() (string, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.AsString()
+}
+func (_List_AuthenticatedRecord__Repr) AsBytes() ([]byte, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.AsBytes()
+}
+func (_List_AuthenticatedRecord__Repr) AsLink() (ipld.Link, error) {
+	return mixins.List{"tasks.List_AuthenticatedRecord.Repr"}.AsLink()
+}
+func (_List_AuthenticatedRecord__Repr) Prototype() ipld.NodePrototype {
+	return _List_AuthenticatedRecord__ReprPrototype{}
+}
+type _List_AuthenticatedRecord__ReprPrototype struct{}
+
+func (_List_AuthenticatedRecord__ReprPrototype) NewBuilder() ipld.NodeBuilder {
+	var nb _List_AuthenticatedRecord__ReprBuilder
+	nb.Reset()
+	return &nb
+}
+type _List_AuthenticatedRecord__ReprBuilder struct {
+	_List_AuthenticatedRecord__ReprAssembler
+}
+func (nb *_List_AuthenticatedRecord__ReprBuilder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_List_AuthenticatedRecord__ReprBuilder) Reset() {
+	var w _List_AuthenticatedRecord
+	var m schema.Maybe
+	*nb = _List_AuthenticatedRecord__ReprBuilder{_List_AuthenticatedRecord__ReprAssembler{w: &w, m: &m}}
+}
+type _List_AuthenticatedRecord__ReprAssembler struct {
+	w *_List_AuthenticatedRecord
+	m *schema.Maybe
+	state laState
+
+	cm schema.Maybe
+	va _AuthenticatedRecord__ReprAssembler
+}
+
+func (na *_List_AuthenticatedRecord__ReprAssembler) reset() {
+	na.state = laState_initial
+	na.va.reset()
+}
+func (_List_AuthenticatedRecord__ReprAssembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.BeginMap(0)
+}
+func (na *_List_AuthenticatedRecord__ReprAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	if na.w == nil {
+		na.w = &_List_AuthenticatedRecord{}
+	}
+	if sizeHint > 0 {
+		na.w.x = make([]_AuthenticatedRecord, 0, sizeHint)
+	}
+	return na, nil
+}
+func (na *_List_AuthenticatedRecord__ReprAssembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr.Repr"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_List_AuthenticatedRecord__ReprAssembler) AssignBool(bool) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.AssignBool(false)
+}
+func (_List_AuthenticatedRecord__ReprAssembler) AssignInt(int64) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.AssignInt(0)
+}
+func (_List_AuthenticatedRecord__ReprAssembler) AssignFloat(float64) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.AssignFloat(0)
+}
+func (_List_AuthenticatedRecord__ReprAssembler) AssignString(string) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.AssignString("")
+}
+func (_List_AuthenticatedRecord__ReprAssembler) AssignBytes([]byte) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.AssignBytes(nil)
+}
+func (_List_AuthenticatedRecord__ReprAssembler) AssignLink(ipld.Link) error {
+	return mixins.ListAssembler{"tasks.List_AuthenticatedRecord.Repr"}.AssignLink(nil)
+}
+func (na *_List_AuthenticatedRecord__ReprAssembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_List_AuthenticatedRecord); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != ipld.Kind_List {
+		return ipld.ErrWrongKind{TypeName: "tasks.List_AuthenticatedRecord.Repr", MethodName: "AssignNode", AppropriateKind: ipld.KindSet_JustList, ActualKind: v.Kind()}
+	}
+	itr := v.ListIterator()
+	for !itr.Done() {
+		_, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_List_AuthenticatedRecord__ReprAssembler) Prototype() ipld.NodePrototype {
+	return _List_AuthenticatedRecord__ReprPrototype{}
+}
+func (la *_List_AuthenticatedRecord__ReprAssembler) valueFinishTidy() bool {
+	switch la.cm {
+	case schema.Maybe_Value:
+		la.va.w = nil
+		la.cm = schema.Maybe_Absent
+		la.state = laState_initial
+		la.va.reset()
+		return true
+	default:
+		return false
+	}
+}
+func (la *_List_AuthenticatedRecord__ReprAssembler) AssembleValue() ipld.NodeAssembler {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: AssembleValue cannot be called when still in the middle of assembling the previous value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	la.w.x = append(la.w.x, _AuthenticatedRecord{})
+	la.state = laState_midValue
+	row := &la.w.x[len(la.w.x)-1]
+	la.va.w = row
+	la.va.m = &la.cm
+	return &la.va
+}
+func (la *_List_AuthenticatedRecord__ReprAssembler) Finish() error {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	la.state = laState_finished
+	*la.m = schema.Maybe_Value
+	return nil
+}
+func (la *_List_AuthenticatedRecord__ReprAssembler) ValuePrototype(_ int64) ipld.NodePrototype {
+	return _AuthenticatedRecord__ReprPrototype{}
 }
 
 func (n *_List_Logs) Lookup(idx int64) Logs {
@@ -8532,6 +10237,912 @@ func (ka *_PopTask__ReprKeyAssembler) AssignNode(v ipld.Node) error {
 	}
 }
 func (_PopTask__ReprKeyAssembler) Prototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+
+
+func (n _RecordUpdate) FieldRecords() List_AuthenticatedRecord {
+	return &n.Records
+}
+func (n _RecordUpdate) FieldPrevious() Link {
+	return &n.Previous
+}
+type _RecordUpdate__Maybe struct {
+	m schema.Maybe
+	v RecordUpdate
+}
+type MaybeRecordUpdate = *_RecordUpdate__Maybe
+
+func (m MaybeRecordUpdate) IsNull() bool {
+	return m.m == schema.Maybe_Null
+}
+func (m MaybeRecordUpdate) IsAbsent() bool {
+	return m.m == schema.Maybe_Absent
+}
+func (m MaybeRecordUpdate) Exists() bool {
+	return m.m == schema.Maybe_Value
+}
+func (m MaybeRecordUpdate) AsNode() ipld.Node {
+	switch m.m {
+		case schema.Maybe_Absent:
+			return ipld.Absent
+		case schema.Maybe_Null:
+			return ipld.Null
+		case schema.Maybe_Value:
+			return m.v
+		default:
+			panic("unreachable")
+	}
+}
+func (m MaybeRecordUpdate) Must() RecordUpdate {
+	if !m.Exists() {
+		panic("unbox of a maybe rejected")
+	}
+	return m.v
+}
+var (
+	fieldName__RecordUpdate_Records = _String{"Records"}
+	fieldName__RecordUpdate_Previous = _String{"Previous"}
+)
+var _ ipld.Node = (RecordUpdate)(&_RecordUpdate{})
+var _ schema.TypedNode = (RecordUpdate)(&_RecordUpdate{})
+func (RecordUpdate) Kind() ipld.Kind {
+	return ipld.Kind_Map
+}
+func (n RecordUpdate) LookupByString(key string) (ipld.Node, error) {
+	switch key {
+	case "Records":
+		return &n.Records, nil
+	case "Previous":
+		return &n.Previous, nil
+	default:
+		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
+	}
+}
+func (n RecordUpdate) LookupByNode(key ipld.Node) (ipld.Node, error) {
+	ks, err := key.AsString()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupByString(ks)
+}
+func (RecordUpdate) LookupByIndex(idx int64) (ipld.Node, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.LookupByIndex(0)
+}
+func (n RecordUpdate) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
+}
+func (n RecordUpdate) MapIterator() ipld.MapIterator {
+	return &_RecordUpdate__MapItr{n, 0}
+}
+
+type _RecordUpdate__MapItr struct {
+	n RecordUpdate
+	idx  int
+}
+
+func (itr *_RecordUpdate__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+	if itr.idx >= 2 {
+		return nil, nil, ipld.ErrIteratorOverread{}
+	}
+	switch itr.idx {
+	case 0:
+		k = &fieldName__RecordUpdate_Records
+		v = &itr.n.Records
+	case 1:
+		k = &fieldName__RecordUpdate_Previous
+		v = &itr.n.Previous
+	default:
+		panic("unreachable")
+	}
+	itr.idx++
+	return
+}
+func (itr *_RecordUpdate__MapItr) Done() bool {
+	return itr.idx >= 2
+}
+
+func (RecordUpdate) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (RecordUpdate) Length() int64 {
+	return 2
+}
+func (RecordUpdate) IsAbsent() bool {
+	return false
+}
+func (RecordUpdate) IsNull() bool {
+	return false
+}
+func (RecordUpdate) AsBool() (bool, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.AsBool()
+}
+func (RecordUpdate) AsInt() (int64, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.AsInt()
+}
+func (RecordUpdate) AsFloat() (float64, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.AsFloat()
+}
+func (RecordUpdate) AsString() (string, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.AsString()
+}
+func (RecordUpdate) AsBytes() ([]byte, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.AsBytes()
+}
+func (RecordUpdate) AsLink() (ipld.Link, error) {
+	return mixins.Map{"tasks.RecordUpdate"}.AsLink()
+}
+func (RecordUpdate) Prototype() ipld.NodePrototype {
+	return _RecordUpdate__Prototype{}
+}
+type _RecordUpdate__Prototype struct{}
+
+func (_RecordUpdate__Prototype) NewBuilder() ipld.NodeBuilder {
+	var nb _RecordUpdate__Builder
+	nb.Reset()
+	return &nb
+}
+type _RecordUpdate__Builder struct {
+	_RecordUpdate__Assembler
+}
+func (nb *_RecordUpdate__Builder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_RecordUpdate__Builder) Reset() {
+	var w _RecordUpdate
+	var m schema.Maybe
+	*nb = _RecordUpdate__Builder{_RecordUpdate__Assembler{w: &w, m: &m}}
+}
+type _RecordUpdate__Assembler struct {
+	w *_RecordUpdate
+	m *schema.Maybe
+	state maState
+	s int
+	f int
+
+	cm schema.Maybe
+	ca_Records _List_AuthenticatedRecord__Assembler
+	ca_Previous _Link__Assembler
+	}
+
+func (na *_RecordUpdate__Assembler) reset() {
+	na.state = maState_initial
+	na.s = 0
+	na.ca_Records.reset()
+	na.ca_Previous.reset()
+}
+
+var (
+	fieldBit__RecordUpdate_Records = 1 << 0
+	fieldBit__RecordUpdate_Previous = 1 << 1
+	fieldBits__RecordUpdate_sufficient = 0 + 1 << 0 + 1 << 1
+)
+func (na *_RecordUpdate__Assembler) BeginMap(int64) (ipld.MapAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if na.w == nil {
+		na.w = &_RecordUpdate{}
+	}
+	return na, nil
+}
+func (_RecordUpdate__Assembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.BeginList(0)
+}
+func (na *_RecordUpdate__Assembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_RecordUpdate__Assembler) AssignBool(bool) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignBool(false)
+}
+func (_RecordUpdate__Assembler) AssignInt(int64) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignInt(0)
+}
+func (_RecordUpdate__Assembler) AssignFloat(float64) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignFloat(0)
+}
+func (_RecordUpdate__Assembler) AssignString(string) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignString("")
+}
+func (_RecordUpdate__Assembler) AssignBytes([]byte) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignBytes(nil)
+}
+func (_RecordUpdate__Assembler) AssignLink(ipld.Link) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate"}.AssignLink(nil)
+}
+func (na *_RecordUpdate__Assembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_RecordUpdate); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != ipld.Kind_Map {
+		return ipld.ErrWrongKind{TypeName: "tasks.RecordUpdate", MethodName: "AssignNode", AppropriateKind: ipld.KindSet_JustMap, ActualKind: v.Kind()}
+	}
+	itr := v.MapIterator()
+	for !itr.Done() {
+		k, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleKey().AssignNode(k); err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_RecordUpdate__Assembler) Prototype() ipld.NodePrototype {
+	return _RecordUpdate__Prototype{}
+}
+func (ma *_RecordUpdate__Assembler) valueFinishTidy() bool {
+	switch ma.f {
+	case 0:
+		switch ma.cm {
+		case schema.Maybe_Value:
+			ma.ca_Records.w = nil
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	case 1:
+		switch ma.cm {
+		case schema.Maybe_Value:
+			ma.ca_Previous.w = nil
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_RecordUpdate__Assembler) AssembleEntry(k string) (ipld.NodeAssembler, error) {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleEntry cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleEntry cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleEntry cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleEntry cannot be called on an assembler that's already finished")
+	}
+	switch k {
+	case "Records":
+		if ma.s & fieldBit__RecordUpdate_Records != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Records}
+		}
+		ma.s += fieldBit__RecordUpdate_Records
+		ma.state = maState_midValue
+		ma.f = 0
+		ma.ca_Records.w = &ma.w.Records
+		ma.ca_Records.m = &ma.cm
+		return &ma.ca_Records, nil
+	case "Previous":
+		if ma.s & fieldBit__RecordUpdate_Previous != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous}
+		}
+		ma.s += fieldBit__RecordUpdate_Previous
+		ma.state = maState_midValue
+		ma.f = 1
+		ma.ca_Previous.w = &ma.w.Previous
+		ma.ca_Previous.m = &ma.cm
+		return &ma.ca_Previous, nil
+	default:
+		return nil, ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate", Key:&_String{k}}
+	}
+}
+func (ma *_RecordUpdate__Assembler) AssembleKey() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleKey cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleKey cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleKey cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleKey cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midKey
+	return (*_RecordUpdate__KeyAssembler)(ma)
+}
+func (ma *_RecordUpdate__Assembler) AssembleValue() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		panic("invalid state: AssembleValue cannot be called when no key is primed")
+	case maState_midKey:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		// carry on
+	case maState_midValue:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling another value")
+	case maState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midValue
+	switch ma.f {
+	case 0:
+		ma.ca_Records.w = &ma.w.Records
+		ma.ca_Records.m = &ma.cm
+		return &ma.ca_Records
+	case 1:
+		ma.ca_Previous.w = &ma.w.Previous
+		ma.ca_Previous.m = &ma.cm
+		return &ma.ca_Previous
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_RecordUpdate__Assembler) Finish() error {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: Finish cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		panic("invalid state: Finish cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	if ma.s & fieldBits__RecordUpdate_sufficient != fieldBits__RecordUpdate_sufficient {
+		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
+		if ma.s & fieldBit__RecordUpdate_Records == 0 {
+			err.Missing = append(err.Missing, "Records")
+		}
+		if ma.s & fieldBit__RecordUpdate_Previous == 0 {
+			err.Missing = append(err.Missing, "Previous")
+		}
+		return err
+	}
+	ma.state = maState_finished
+	*ma.m = schema.Maybe_Value
+	return nil
+}
+func (ma *_RecordUpdate__Assembler) KeyPrototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+func (ma *_RecordUpdate__Assembler) ValuePrototype(k string) ipld.NodePrototype {
+	panic("todo structbuilder mapassembler valueprototype")
+}
+type _RecordUpdate__KeyAssembler _RecordUpdate__Assembler
+func (_RecordUpdate__KeyAssembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.BeginMap(0)
+}
+func (_RecordUpdate__KeyAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.BeginList(0)
+}
+func (na *_RecordUpdate__KeyAssembler) AssignNull() error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.AssignNull()
+}
+func (_RecordUpdate__KeyAssembler) AssignBool(bool) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.AssignBool(false)
+}
+func (_RecordUpdate__KeyAssembler) AssignInt(int64) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.AssignInt(0)
+}
+func (_RecordUpdate__KeyAssembler) AssignFloat(float64) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.AssignFloat(0)
+}
+func (ka *_RecordUpdate__KeyAssembler) AssignString(k string) error {
+	if ka.state != maState_midKey {
+		panic("misuse: KeyAssembler held beyond its valid lifetime")
+	}
+	switch k {
+	case "Records":
+		if ka.s & fieldBit__RecordUpdate_Records != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Records}
+		}
+		ka.s += fieldBit__RecordUpdate_Records
+		ka.state = maState_expectValue
+		ka.f = 0
+	case "Previous":
+		if ka.s & fieldBit__RecordUpdate_Previous != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous}
+		}
+		ka.s += fieldBit__RecordUpdate_Previous
+		ka.state = maState_expectValue
+		ka.f = 1
+	default:
+		return ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate", Key:&_String{k}}
+	}
+	return nil
+}
+func (_RecordUpdate__KeyAssembler) AssignBytes([]byte) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.AssignBytes(nil)
+}
+func (_RecordUpdate__KeyAssembler) AssignLink(ipld.Link) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.KeyAssembler"}.AssignLink(nil)
+}
+func (ka *_RecordUpdate__KeyAssembler) AssignNode(v ipld.Node) error {
+	if v2, err := v.AsString(); err != nil {
+		return err
+	} else {
+		return ka.AssignString(v2)
+	}
+}
+func (_RecordUpdate__KeyAssembler) Prototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+func (RecordUpdate) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (n RecordUpdate) Representation() ipld.Node {
+	return (*_RecordUpdate__Repr)(n)
+}
+type _RecordUpdate__Repr _RecordUpdate
+var (
+	fieldName__RecordUpdate_Records_serial = _String{"Records"}
+	fieldName__RecordUpdate_Previous_serial = _String{"Previous"}
+)
+var _ ipld.Node = &_RecordUpdate__Repr{}
+func (_RecordUpdate__Repr) Kind() ipld.Kind {
+	return ipld.Kind_Map
+}
+func (n *_RecordUpdate__Repr) LookupByString(key string) (ipld.Node, error) {
+	switch key {
+	case "Records":
+		return n.Records.Representation(), nil
+	case "Previous":
+		return n.Previous.Representation(), nil
+	default:
+		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
+	}
+}
+func (n *_RecordUpdate__Repr) LookupByNode(key ipld.Node) (ipld.Node, error) {
+	ks, err := key.AsString()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupByString(ks)
+}
+func (_RecordUpdate__Repr) LookupByIndex(idx int64) (ipld.Node, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.LookupByIndex(0)
+}
+func (n _RecordUpdate__Repr) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
+}
+func (n *_RecordUpdate__Repr) MapIterator() ipld.MapIterator {
+	return &_RecordUpdate__ReprMapItr{n, 0}
+}
+
+type _RecordUpdate__ReprMapItr struct {
+	n   *_RecordUpdate__Repr
+	idx int
+	
+}
+
+func (itr *_RecordUpdate__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+if itr.idx >= 2 {
+		return nil, nil, ipld.ErrIteratorOverread{}
+	}
+	switch itr.idx {
+	case 0:
+		k = &fieldName__RecordUpdate_Records_serial
+		v = itr.n.Records.Representation()
+	case 1:
+		k = &fieldName__RecordUpdate_Previous_serial
+		v = itr.n.Previous.Representation()
+	default:
+		panic("unreachable")
+	}
+	itr.idx++
+	return
+}
+func (itr *_RecordUpdate__ReprMapItr) Done() bool {
+	return itr.idx >= 2
+}
+func (_RecordUpdate__Repr) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (rn *_RecordUpdate__Repr) Length() int64 {
+	l := 2
+	return int64(l)
+}
+func (_RecordUpdate__Repr) IsAbsent() bool {
+	return false
+}
+func (_RecordUpdate__Repr) IsNull() bool {
+	return false
+}
+func (_RecordUpdate__Repr) AsBool() (bool, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.AsBool()
+}
+func (_RecordUpdate__Repr) AsInt() (int64, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.AsInt()
+}
+func (_RecordUpdate__Repr) AsFloat() (float64, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.AsFloat()
+}
+func (_RecordUpdate__Repr) AsString() (string, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.AsString()
+}
+func (_RecordUpdate__Repr) AsBytes() ([]byte, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.AsBytes()
+}
+func (_RecordUpdate__Repr) AsLink() (ipld.Link, error) {
+	return mixins.Map{"tasks.RecordUpdate.Repr"}.AsLink()
+}
+func (_RecordUpdate__Repr) Prototype() ipld.NodePrototype {
+	return _RecordUpdate__ReprPrototype{}
+}
+type _RecordUpdate__ReprPrototype struct{}
+
+func (_RecordUpdate__ReprPrototype) NewBuilder() ipld.NodeBuilder {
+	var nb _RecordUpdate__ReprBuilder
+	nb.Reset()
+	return &nb
+}
+type _RecordUpdate__ReprBuilder struct {
+	_RecordUpdate__ReprAssembler
+}
+func (nb *_RecordUpdate__ReprBuilder) Build() ipld.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_RecordUpdate__ReprBuilder) Reset() {
+	var w _RecordUpdate
+	var m schema.Maybe
+	*nb = _RecordUpdate__ReprBuilder{_RecordUpdate__ReprAssembler{w: &w, m: &m}}
+}
+type _RecordUpdate__ReprAssembler struct {
+	w *_RecordUpdate
+	m *schema.Maybe
+	state maState
+	s int
+	f int
+
+	cm schema.Maybe
+	ca_Records _List_AuthenticatedRecord__ReprAssembler
+	ca_Previous _Link__ReprAssembler
+	}
+
+func (na *_RecordUpdate__ReprAssembler) reset() {
+	na.state = maState_initial
+	na.s = 0
+	na.ca_Records.reset()
+	na.ca_Previous.reset()
+}
+func (na *_RecordUpdate__ReprAssembler) BeginMap(int64) (ipld.MapAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if na.w == nil {
+		na.w = &_RecordUpdate{}
+	}
+	return na, nil
+}
+func (_RecordUpdate__ReprAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.BeginList(0)
+}
+func (na *_RecordUpdate__ReprAssembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.MapAssembler{"tasks.RecordUpdate.Repr.Repr"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_RecordUpdate__ReprAssembler) AssignBool(bool) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.AssignBool(false)
+}
+func (_RecordUpdate__ReprAssembler) AssignInt(int64) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.AssignInt(0)
+}
+func (_RecordUpdate__ReprAssembler) AssignFloat(float64) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.AssignFloat(0)
+}
+func (_RecordUpdate__ReprAssembler) AssignString(string) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.AssignString("")
+}
+func (_RecordUpdate__ReprAssembler) AssignBytes([]byte) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.AssignBytes(nil)
+}
+func (_RecordUpdate__ReprAssembler) AssignLink(ipld.Link) error {
+	return mixins.MapAssembler{"tasks.RecordUpdate.Repr"}.AssignLink(nil)
+}
+func (na *_RecordUpdate__ReprAssembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_RecordUpdate); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		if na.w == nil {
+			na.w = v2
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != ipld.Kind_Map {
+		return ipld.ErrWrongKind{TypeName: "tasks.RecordUpdate.Repr", MethodName: "AssignNode", AppropriateKind: ipld.KindSet_JustMap, ActualKind: v.Kind()}
+	}
+	itr := v.MapIterator()
+	for !itr.Done() {
+		k, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleKey().AssignNode(k); err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_RecordUpdate__ReprAssembler) Prototype() ipld.NodePrototype {
+	return _RecordUpdate__ReprPrototype{}
+}
+func (ma *_RecordUpdate__ReprAssembler) valueFinishTidy() bool {
+	switch ma.f {
+	case 0:
+		switch ma.cm {
+		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	case 1:
+		switch ma.cm {
+		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_RecordUpdate__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssembler, error) {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleEntry cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleEntry cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleEntry cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleEntry cannot be called on an assembler that's already finished")
+	}
+	switch k {
+	case "Records":
+		if ma.s & fieldBit__RecordUpdate_Records != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Records_serial}
+		}
+		ma.s += fieldBit__RecordUpdate_Records
+		ma.state = maState_midValue
+		ma.f = 0
+		ma.ca_Records.w = &ma.w.Records
+		ma.ca_Records.m = &ma.cm
+		return &ma.ca_Records, nil
+	case "Previous":
+		if ma.s & fieldBit__RecordUpdate_Previous != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous_serial}
+		}
+		ma.s += fieldBit__RecordUpdate_Previous
+		ma.state = maState_midValue
+		ma.f = 1
+		ma.ca_Previous.w = &ma.w.Previous
+		ma.ca_Previous.m = &ma.cm
+		return &ma.ca_Previous, nil
+	default:
+		return nil, ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate.Repr", Key:&_String{k}}
+	}
+}
+func (ma *_RecordUpdate__ReprAssembler) AssembleKey() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: AssembleKey cannot be called when in the middle of assembling another key")
+	case maState_expectValue:
+		panic("invalid state: AssembleKey cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: AssembleKey cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: AssembleKey cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midKey
+	return (*_RecordUpdate__ReprKeyAssembler)(ma)
+}
+func (ma *_RecordUpdate__ReprAssembler) AssembleValue() ipld.NodeAssembler {
+	switch ma.state {
+	case maState_initial:
+		panic("invalid state: AssembleValue cannot be called when no key is primed")
+	case maState_midKey:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		// carry on
+	case maState_midValue:
+		panic("invalid state: AssembleValue cannot be called when in the middle of assembling another value")
+	case maState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	ma.state = maState_midValue
+	switch ma.f {
+	case 0:
+		ma.ca_Records.w = &ma.w.Records
+		ma.ca_Records.m = &ma.cm
+		return &ma.ca_Records
+	case 1:
+		ma.ca_Previous.w = &ma.w.Previous
+		ma.ca_Previous.m = &ma.cm
+		return &ma.ca_Previous
+	default:
+		panic("unreachable")
+	}
+}
+func (ma *_RecordUpdate__ReprAssembler) Finish() error {
+	switch ma.state {
+	case maState_initial:
+		// carry on
+	case maState_midKey:
+		panic("invalid state: Finish cannot be called when in the middle of assembling a key")
+	case maState_expectValue:
+		panic("invalid state: Finish cannot be called when expecting start of value assembly")
+	case maState_midValue:
+		if !ma.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case maState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	if ma.s & fieldBits__RecordUpdate_sufficient != fieldBits__RecordUpdate_sufficient {
+		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
+		if ma.s & fieldBit__RecordUpdate_Records == 0 {
+			err.Missing = append(err.Missing, "Records")
+		}
+		if ma.s & fieldBit__RecordUpdate_Previous == 0 {
+			err.Missing = append(err.Missing, "Previous")
+		}
+		return err
+	}
+	ma.state = maState_finished
+	*ma.m = schema.Maybe_Value
+	return nil
+}
+func (ma *_RecordUpdate__ReprAssembler) KeyPrototype() ipld.NodePrototype {
+	return _String__Prototype{}
+}
+func (ma *_RecordUpdate__ReprAssembler) ValuePrototype(k string) ipld.NodePrototype {
+	panic("todo structbuilder mapassembler repr valueprototype")
+}
+type _RecordUpdate__ReprKeyAssembler _RecordUpdate__ReprAssembler
+func (_RecordUpdate__ReprKeyAssembler) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.BeginMap(0)
+}
+func (_RecordUpdate__ReprKeyAssembler) BeginList(sizeHint int64) (ipld.ListAssembler, error) {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.BeginList(0)
+}
+func (na *_RecordUpdate__ReprKeyAssembler) AssignNull() error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.AssignNull()
+}
+func (_RecordUpdate__ReprKeyAssembler) AssignBool(bool) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.AssignBool(false)
+}
+func (_RecordUpdate__ReprKeyAssembler) AssignInt(int64) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.AssignInt(0)
+}
+func (_RecordUpdate__ReprKeyAssembler) AssignFloat(float64) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.AssignFloat(0)
+}
+func (ka *_RecordUpdate__ReprKeyAssembler) AssignString(k string) error {
+	if ka.state != maState_midKey {
+		panic("misuse: KeyAssembler held beyond its valid lifetime")
+	}
+	switch k {
+	case "Records":
+		if ka.s & fieldBit__RecordUpdate_Records != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Records_serial}
+		}
+		ka.s += fieldBit__RecordUpdate_Records
+		ka.state = maState_expectValue
+		ka.f = 0
+	case "Previous":
+		if ka.s & fieldBit__RecordUpdate_Previous != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__RecordUpdate_Previous_serial}
+		}
+		ka.s += fieldBit__RecordUpdate_Previous
+		ka.state = maState_expectValue
+		ka.f = 1
+	default:
+		return ipld.ErrInvalidKey{TypeName:"tasks.RecordUpdate.Repr", Key:&_String{k}}
+	}
+	return nil
+}
+func (_RecordUpdate__ReprKeyAssembler) AssignBytes([]byte) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.AssignBytes(nil)
+}
+func (_RecordUpdate__ReprKeyAssembler) AssignLink(ipld.Link) error {
+	return mixins.StringAssembler{"tasks.RecordUpdate.Repr.KeyAssembler"}.AssignLink(nil)
+}
+func (ka *_RecordUpdate__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+	if v2, err := v.AsString(); err != nil {
+		return err
+	} else {
+		return ka.AssignString(v2)
+	}
+}
+func (_RecordUpdate__ReprKeyAssembler) Prototype() ipld.NodePrototype {
 	return _String__Prototype{}
 }
 

--- a/tasks/ipldsch_types.go
+++ b/tasks/ipldsch_types.go
@@ -199,7 +199,7 @@ type RecordUpdate = *_RecordUpdate
 type _RecordUpdate struct {
 	Records _List_AuthenticatedRecord
 	SigPrev _Bytes
-	Previous _Link
+	Previous _Link__Maybe
 }
 
 // RetrievalTask matches the IPLD Schema type "RetrievalTask".  It has Struct type-kind, and may be interrogated like map kind.

--- a/tasks/ipldsch_types.go
+++ b/tasks/ipldsch_types.go
@@ -21,6 +21,8 @@ var Type typeSlab
 type typeSlab struct {
 	Any       _Any__Prototype
 	Any__Repr _Any__ReprPrototype
+	AuthenticatedRecord       _AuthenticatedRecord__Prototype
+	AuthenticatedRecord__Repr _AuthenticatedRecord__ReprPrototype
 	Bool       _Bool__Prototype
 	Bool__Repr _Bool__ReprPrototype
 	Bytes       _Bytes__Prototype
@@ -33,10 +35,14 @@ type typeSlab struct {
 	Int__Repr _Int__ReprPrototype
 	Link       _Link__Prototype
 	Link__Repr _Link__ReprPrototype
+	Link_FinishedTask       _Link_FinishedTask__Prototype
+	Link_FinishedTask__Repr _Link_FinishedTask__ReprPrototype
 	Link_List_StageDetails       _Link_List_StageDetails__Prototype
 	Link_List_StageDetails__Repr _Link_List_StageDetails__ReprPrototype
 	List       _List__Prototype
 	List__Repr _List__ReprPrototype
+	List_AuthenticatedRecord       _List_AuthenticatedRecord__Prototype
+	List_AuthenticatedRecord__Repr _List_AuthenticatedRecord__ReprPrototype
 	List_Logs       _List_Logs__Prototype
 	List_Logs__Repr _List_Logs__ReprPrototype
 	List_StageDetails       _List_StageDetails__Prototype
@@ -47,6 +53,8 @@ type typeSlab struct {
 	Map__Repr _Map__ReprPrototype
 	PopTask       _PopTask__Prototype
 	PopTask__Repr _PopTask__ReprPrototype
+	RecordUpdate       _RecordUpdate__Prototype
+	RecordUpdate__Repr _RecordUpdate__ReprPrototype
 	RetrievalTask       _RetrievalTask__Prototype
 	RetrievalTask__Repr _RetrievalTask__ReprPrototype
 	StageDetails       _StageDetails__Prototype
@@ -86,6 +94,13 @@ func (_Map) _Any__member() {}
 func (_List) _Any__member() {}
 func (_Link) _Any__member() {}
 
+// AuthenticatedRecord matches the IPLD Schema type "AuthenticatedRecord".  It has Struct type-kind, and may be interrogated like map kind.
+type AuthenticatedRecord = *_AuthenticatedRecord
+type _AuthenticatedRecord struct {
+	Record _Link_FinishedTask
+	Signature _Bytes
+}
+
 // Bool matches the IPLD Schema type "Bool".  It has bool kind.
 type Bool = *_Bool
 type _Bool struct{ x bool }
@@ -122,6 +137,10 @@ type _Int struct{ x int64 }
 type Link = *_Link
 type _Link struct{ x ipld.Link }
 
+// Link_FinishedTask matches the IPLD Schema type "Link_FinishedTask".  It has link kind.
+type Link_FinishedTask = *_Link_FinishedTask
+type _Link_FinishedTask struct{ x ipld.Link }
+
 // Link_List_StageDetails matches the IPLD Schema type "Link_List_StageDetails".  It has link kind.
 type Link_List_StageDetails = *_Link_List_StageDetails
 type _Link_List_StageDetails struct{ x ipld.Link }
@@ -130,6 +149,12 @@ type _Link_List_StageDetails struct{ x ipld.Link }
 type List = *_List
 type _List struct {
 	x []_Any__Maybe
+}
+
+// List_AuthenticatedRecord matches the IPLD Schema type "List_AuthenticatedRecord".  It has list kind.
+type List_AuthenticatedRecord = *_List_AuthenticatedRecord
+type _List_AuthenticatedRecord struct {
+	x []_AuthenticatedRecord
 }
 
 // List_Logs matches the IPLD Schema type "List_Logs".  It has list kind.
@@ -167,6 +192,13 @@ type PopTask = *_PopTask
 type _PopTask struct {
 	Status _Status
 	WorkedBy _String
+}
+
+// RecordUpdate matches the IPLD Schema type "RecordUpdate".  It has Struct type-kind, and may be interrogated like map kind.
+type RecordUpdate = *_RecordUpdate
+type _RecordUpdate struct {
+	Records _List_AuthenticatedRecord
+	Previous _Link
 }
 
 // RetrievalTask matches the IPLD Schema type "RetrievalTask".  It has Struct type-kind, and may be interrogated like map kind.

--- a/tasks/ipldsch_types.go
+++ b/tasks/ipldsch_types.go
@@ -198,6 +198,7 @@ type _PopTask struct {
 type RecordUpdate = *_RecordUpdate
 type _RecordUpdate struct {
 	Records _List_AuthenticatedRecord
+	SigPrev _Bytes
 	Previous _Link
 }
 

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -337,3 +337,30 @@ func (ts *_Tasks) List() []Task {
 	}
 	return itms
 }
+
+func (arp *_AuthenticatedRecord__Prototype) Of(c cid.Cid, sig []byte) *_AuthenticatedRecord {
+	ar := _AuthenticatedRecord{
+		Record:    _Link_FinishedTask{x: linksystem.Link{Cid: c}},
+		Signature: _Bytes{x: sig},
+	}
+	return &ar
+}
+
+func (alp *_List_AuthenticatedRecord__Prototype) Of(ars []*_AuthenticatedRecord) *_List_AuthenticatedRecord {
+	al := _List_AuthenticatedRecord{
+		x: []_AuthenticatedRecord{},
+	}
+	for _, a := range ars {
+		al.x = append(al.x, *a)
+	}
+	return &al
+}
+
+func (rup *_RecordUpdate__Prototype) Of(rcrds *_List_AuthenticatedRecord, previous cid.Cid, previousSig []byte) *_RecordUpdate {
+	ru := _RecordUpdate{
+		Records:  *rcrds,
+		SigPrev:  _Bytes{x: previousSig},
+		Previous: _Link{linksystem.Link{Cid: previous}},
+	}
+	return &ru
+}

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -357,10 +357,15 @@ func (alp *_List_AuthenticatedRecord__Prototype) Of(ars []*_AuthenticatedRecord)
 }
 
 func (rup *_RecordUpdate__Prototype) Of(rcrds *_List_AuthenticatedRecord, previous cid.Cid, previousSig []byte) *_RecordUpdate {
+	lrm := _Link__Maybe{m: schema.Maybe_Null, v: nil}
+	if previous != cid.Undef {
+		lrm.m = schema.Maybe_Value
+		lrm.v = &_Link{x: linksystem.Link{Cid: previous}}
+	}
 	ru := _RecordUpdate{
 		Records:  *rcrds,
 		SigPrev:  _Bytes{x: previousSig},
-		Previous: _Link{linksystem.Link{Cid: previous}},
+		Previous: lrm,
 	}
 	return &ru
 }


### PR DESCRIPTION
this builds the top level scaffold expected to be consumed by reputation systems

* A new command for now to indicate all work by a given bot is done, at which point all finalized tasks from that bot are collected into a record update that is set as the new 'head'
* A graphql endpoint to query against this chain.