### PR TITLE
Fix missing stage update history

### DIFF
--- a/tasks/model.go
+++ b/tasks/model.go
@@ -254,6 +254,8 @@ func (t *_Task) Update(status Status, stage string, errorMessage string, details
 		} else {
 			updatedTask.PastStageDetails = _List_StageDetails__Maybe{m: schema.Maybe_Value, v: &_List_StageDetails{x: append(t.PastStageDetails.v.x, *t.CurrentStageDetails.v)}}
 		}
+	} else {
+		updatedTask.PastStageDetails = t.PastStageDetails
 	}
 
 	if details == nil {


### PR DESCRIPTION
When an update does not add additional stage history to a task, it was not keeping the current history.  This fixes the problem so that the previous stage history is retained.

Fixes #125