### PR TITLE
Make error message optional

### DIFF
--- a/controller/graphql/schema.go
+++ b/controller/graphql/schema.go
@@ -36,981 +36,6 @@ func resolve_map_at(p graphql.ResolveParams) (interface{}, error) {
         return nil, fmt.Errorf("unknown key type: %T", arg)
     }
 }
-var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_Logs",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Logs__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Logs__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_Logs)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldUUID().AsString()
-    
-}
-func Task__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStatus(), nil
-    
-}
-func Task__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldWorkedBy()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldStage().AsString()
-    
-}
-func Task__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldCurrentStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__PastStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldPastStageDetails()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStartedAt()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__RunCount__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldRunCount().AsInt()
-    
-}
-func Task__ErrorMessage__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldErrorMessage().AsString()
-    
-}
-func Task__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldRetrievalTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func Task__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.Task)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldStorageTask()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var Task__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Task",
-    Fields: graphql.Fields{
-        "UUID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__UUID__resolve,
-        },
-        "Status": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Status__type),
-            
-            Resolve: Task__Status__resolve,
-        },
-        "WorkedBy": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: Task__WorkedBy__resolve,
-        },
-        "Stage": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__Stage__resolve,
-        },
-        "CurrentStageDetails": &graphql.Field{
-            
-            Type: StageDetails__type,
-            
-            Resolve: Task__CurrentStageDetails__resolve,
-        },
-        "PastStageDetails": &graphql.Field{
-            
-            Type: List_StageDetails__type,
-            
-            Resolve: Task__PastStageDetails__resolve,
-        },
-        "StartedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: Task__StartedAt__resolve,
-        },
-        "RunCount": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Int),
-            
-            Resolve: Task__RunCount__resolve,
-        },
-        "ErrorMessage": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: Task__ErrorMessage__resolve,
-        },
-        "RetrievalTask": &graphql.Field{
-            
-            Type: RetrievalTask__type,
-            
-            Resolve: Task__RetrievalTask__resolve,
-        },
-        "StorageTask": &graphql.Field{
-            
-            Type: StorageTask__type,
-            
-            Resolve: Task__StorageTask__resolve,
-        },
-    },
-})
-func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldDescription()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldExpectedDuration()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldLogs(), nil
-    
-}
-func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.StageDetails)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldUpdatedAt()
-    if f.Exists() {
-        
-        return f.Must(), nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "StageDetails",
-    Fields: graphql.Fields{
-        "Description": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: StageDetails__Description__resolve,
-        },
-        "ExpectedDuration": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: StageDetails__ExpectedDuration__resolve,
-        },
-        "Logs": &graphql.Field{
-            
-            Type: graphql.NewNonNull(List_Logs__type),
-            
-            Resolve: StageDetails__Logs__resolve,
-        },
-        "UpdatedAt": &graphql.Field{
-            
-            Type: Time__type,
-            
-            Resolve: StageDetails__UpdatedAt__resolve,
-        },
-    },
-})
-var Any__type = graphql.NewUnion(graphql.UnionConfig{
-    Name: "Any",
-    Types: []*graphql.Object{
-        
-        union__Any__Bool,
-        
-        
-        union__Any__Int,
-        
-        
-        union__Any__Float,
-        
-        
-        union__Any__String,
-        
-        
-        union__Any__Bytes,
-        
-        
-        union__Any__Map,
-        
-        
-        union__Any__List,
-        
-        
-        union__Any__Link,
-        
-    },
-    ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
-        if node, ok := p.Value.(ipld.Node); ok {
-            switch node.Prototype() {
-            
-            case tasks.Type.Bool:
-                fallthrough
-            case tasks.Type.Bool__Repr:
-                return union__Any__Bool
-            
-            
-            case tasks.Type.Int:
-                fallthrough
-            case tasks.Type.Int__Repr:
-                return union__Any__Int
-            
-            
-            case tasks.Type.Float:
-                fallthrough
-            case tasks.Type.Float__Repr:
-                return union__Any__Float
-            
-            
-            case tasks.Type.String:
-                fallthrough
-            case tasks.Type.String__Repr:
-                return union__Any__String
-            
-            
-            case tasks.Type.Bytes:
-                fallthrough
-            case tasks.Type.Bytes__Repr:
-                return union__Any__Bytes
-            
-            
-            case tasks.Type.Map:
-                fallthrough
-            case tasks.Type.Map__Repr:
-                return union__Any__Map
-            
-            
-            case tasks.Type.List:
-                fallthrough
-            case tasks.Type.List__Repr:
-                return union__Any__List
-            
-            
-            case tasks.Type.Link:
-                fallthrough
-            case tasks.Type.Link__Repr:
-                return union__Any__Link
-            
-            }				
-        }
-        fmt.Printf("Actual type %T: %v not in union\n", p.Value, p.Value)
-        return nil
-    },
-})
-
-var union__Any__Bool = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Bool",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.Boolean,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Bool)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsBool()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__Int = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Int",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.Int,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Int)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsInt()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__Float = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Float",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.Float,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Float)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsFloat()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__String = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.String",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-        "": &graphql.Field{
-            Type: graphql.String,
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.String)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.AsString()
-            },
-        },
-        
-    },
-})
-
-
-var union__Any__Bytes = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Bytes",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-
-var union__Any__Map = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Map",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-
-var union__Any__List = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.List",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-
-var union__Any__Link = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Any.Link",
-    Description: "Synthetic union member wrapper",
-    Fields: graphql.Fields{
-        
-    },
-})
-
-func Status__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        i, err := value.AsInt()
-        if err != nil {
-            return err
-        }
-        return i
-        
-    default:
-        return nil
-    }
-}
-func Status__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Status__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Status__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Status__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Status__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Status",
-    Description: "Status",
-    Serialize: Status__type__serialize,
-    ParseValue: Status__type__parse,
-    ParseLiteral: Status__type__parseLiteral,
-})
-func AuthenticatedRecord__Record__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.AuthenticatedRecord)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    targetCid := ts.FieldRecord().Link()
-    
-			var node ipld.Node
-			
-	if cl, ok := targetCid.(cidlink.Link); ok {
-		v := p.Context.Value(nodeLoaderCtxKey)
-		if v == nil {
-			return cl.Cid, nil
-		}
-		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
-		if !ok {
-			return nil, errInvalidLoader
-		}
-
-		builder := tasks.Type.FinishedTask__Repr.NewBuilder()
-		n, err := loader(p.Context, cl, builder);
-		if err != nil {
-			return nil, err
-		}
-		node = n
-	} else {
-		return nil, errInvalidLink
-	}
-	
-			return node, nil
-			
-    
-}
-func AuthenticatedRecord__Signature__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.AuthenticatedRecord)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldSignature(), nil
-    
-}
-var AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "AuthenticatedRecord",
-    Fields: graphql.Fields{
-        "Record": &graphql.Field{
-            
-            Type: graphql.NewNonNull(FinishedTask__type),
-            
-            Resolve: AuthenticatedRecord__Record__resolve,
-        },
-        "Signature": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Bytes__type),
-            
-            Resolve: AuthenticatedRecord__Signature__resolve,
-        },
-    },
-})
-var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_StageDetails",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: StageDetails__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(StageDetails__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(StageDetails__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_StageDetails)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldMiner().AsString()
-    
-}
-func RetrievalTask__PayloadCID__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldPayloadCID().AsString()
-    
-}
-func RetrievalTask__CARExport__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldCARExport().AsBool()
-    
-}
-func RetrievalTask__Schedule__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldSchedule()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-func RetrievalTask__ScheduleLimit__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RetrievalTask)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldScheduleLimit()
-    if f.Exists() {
-        
-        return f.Must().AsString()
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "RetrievalTask",
-    Fields: graphql.Fields{
-        "Miner": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: RetrievalTask__Miner__resolve,
-        },
-        "PayloadCID": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.String),
-            
-            Resolve: RetrievalTask__PayloadCID__resolve,
-        },
-        "CARExport": &graphql.Field{
-            
-            Type: graphql.NewNonNull(graphql.Boolean),
-            
-            Resolve: RetrievalTask__CARExport__resolve,
-        },
-        "Schedule": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: RetrievalTask__Schedule__resolve,
-        },
-        "ScheduleLimit": &graphql.Field{
-            
-            Type: graphql.String,
-            
-            Resolve: RetrievalTask__ScheduleLimit__resolve,
-        },
-    },
-})
-var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "Tasks",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: Task__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(Task__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.Tasks)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
 func StorageTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.StorageTask)
     if !ok {
@@ -1266,6 +291,207 @@ var UpdateTask__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
+var Any__type = graphql.NewUnion(graphql.UnionConfig{
+    Name: "Any",
+    Types: []*graphql.Object{
+        
+        union__Any__Bool,
+        
+        
+        union__Any__Int,
+        
+        
+        union__Any__Float,
+        
+        
+        union__Any__String,
+        
+        
+        union__Any__Bytes,
+        
+        
+        union__Any__Map,
+        
+        
+        union__Any__List,
+        
+        
+        union__Any__Link,
+        
+    },
+    ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+        if node, ok := p.Value.(ipld.Node); ok {
+            switch node.Prototype() {
+            
+            case tasks.Type.Bool:
+                fallthrough
+            case tasks.Type.Bool__Repr:
+                return union__Any__Bool
+            
+            
+            case tasks.Type.Int:
+                fallthrough
+            case tasks.Type.Int__Repr:
+                return union__Any__Int
+            
+            
+            case tasks.Type.Float:
+                fallthrough
+            case tasks.Type.Float__Repr:
+                return union__Any__Float
+            
+            
+            case tasks.Type.String:
+                fallthrough
+            case tasks.Type.String__Repr:
+                return union__Any__String
+            
+            
+            case tasks.Type.Bytes:
+                fallthrough
+            case tasks.Type.Bytes__Repr:
+                return union__Any__Bytes
+            
+            
+            case tasks.Type.Map:
+                fallthrough
+            case tasks.Type.Map__Repr:
+                return union__Any__Map
+            
+            
+            case tasks.Type.List:
+                fallthrough
+            case tasks.Type.List__Repr:
+                return union__Any__List
+            
+            
+            case tasks.Type.Link:
+                fallthrough
+            case tasks.Type.Link__Repr:
+                return union__Any__Link
+            
+            }				
+        }
+        fmt.Printf("Actual type %T: %v not in union\n", p.Value, p.Value)
+        return nil
+    },
+})
+
+var union__Any__Bool = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Bool",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.Boolean,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Bool)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsBool()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__Int = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Int",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.Int,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Int)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsInt()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__Float = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Float",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.Float,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Float)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsFloat()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__String = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.String",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+        "": &graphql.Field{
+            Type: graphql.String,
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.String)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.AsString()
+            },
+        },
+        
+    },
+})
+
+
+var union__Any__Bytes = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Bytes",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+
+var union__Any__Map = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Map",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+
+var union__Any__List = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.List",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
+
+var union__Any__Link = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Any.Link",
+    Description: "Synthetic union member wrapper",
+    Fields: graphql.Fields{
+        
+    },
+})
+
 func Bytes__type__serialize(value interface{}) interface{} {
     switch value := value.(type) {
     case ipld.Node:
@@ -1309,49 +535,192 @@ var Bytes__type = graphql.NewScalar(graphql.ScalarConfig{
     ParseValue: Bytes__type__parse,
     ParseLiteral: Bytes__type__parseLiteral,
 })
-func Time__type__serialize(value interface{}) interface{} {
-    switch value := value.(type) {
-    case ipld.Node:
-        
-        i, err := value.AsInt()
-        if err != nil {
-            return err
-        }
-        return i
-        
-    default:
-        return nil
-    }
-}
-func Time__type__parse(value interface{}) interface{} {
-    builder := tasks.Type.Time__Repr.NewBuilder()
-    switch v2 := value.(type) {
-    case string:
-        builder.AssignString(v2)
-    case *string:
-        builder.AssignString(*v2)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-func Time__type__parseLiteral(valueAST ast.Value) interface{} {
-    builder := tasks.Type.Time__Repr.NewBuilder()
-    switch valueAST := valueAST.(type) {
-    case *ast.StringValue:
-        builder.AssignString(valueAST.Value)
-    default:
-        return nil
-    }
-    return builder.Build()
-}
-var Time__type = graphql.NewScalar(graphql.ScalarConfig{
-    Name:        "Time",
-    Description: "Time",
-    Serialize: Time__type__serialize,
-    ParseValue: Time__type__parse,
-    ParseLiteral: Time__type__parseLiteral,
-})
+var List_StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_StageDetails",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: StageDetails__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(StageDetails__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(StageDetails__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_StageDetails)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+var Tasks__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Tasks",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Task__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Task__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.Tasks)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
 func FinishedTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.FinishedTask)
     if !ok {
@@ -1376,7 +745,14 @@ func FinishedTask__ErrorMessage__resolve(p graphql.ResolveParams) (interface{}, 
         return nil, errNotNode
     }
     
-    return ts.FieldErrorMessage().AsString()
+    f := ts.FieldErrorMessage()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
     
 }
 func FinishedTask__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
@@ -1537,7 +913,7 @@ var FinishedTask__type = graphql.NewObject(graphql.ObjectConfig{
         },
         "ErrorMessage": &graphql.Field{
             
-            Type: graphql.NewNonNull(graphql.String),
+            Type: graphql.String,
             
             Resolve: FinishedTask__ErrorMessage__resolve,
         },
@@ -1597,6 +973,448 @@ var FinishedTask__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })
+func RetrievalTask__Miner__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldMiner().AsString()
+    
+}
+func RetrievalTask__PayloadCID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldPayloadCID().AsString()
+    
+}
+func RetrievalTask__CARExport__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldCARExport().AsBool()
+    
+}
+func RetrievalTask__Schedule__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldSchedule()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func RetrievalTask__ScheduleLimit__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RetrievalTask)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldScheduleLimit()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var RetrievalTask__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "RetrievalTask",
+    Fields: graphql.Fields{
+        "Miner": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: RetrievalTask__Miner__resolve,
+        },
+        "PayloadCID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: RetrievalTask__PayloadCID__resolve,
+        },
+        "CARExport": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Boolean),
+            
+            Resolve: RetrievalTask__CARExport__resolve,
+        },
+        "Schedule": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: RetrievalTask__Schedule__resolve,
+        },
+        "ScheduleLimit": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: RetrievalTask__ScheduleLimit__resolve,
+        },
+    },
+})
+func Time__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        i, err := value.AsInt()
+        if err != nil {
+            return err
+        }
+        return i
+        
+    default:
+        return nil
+    }
+}
+func Time__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Time__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Time__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Time__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Time__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Time",
+    Description: "Time",
+    Serialize: Time__type__serialize,
+    ParseValue: Time__type__parse,
+    ParseLiteral: Time__type__parseLiteral,
+})
+func StageDetails__Description__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldDescription()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__ExpectedDuration__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldExpectedDuration()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func StageDetails__Logs__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldLogs(), nil
+    
+}
+func StageDetails__UpdatedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StageDetails)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldUpdatedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var StageDetails__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "StageDetails",
+    Fields: graphql.Fields{
+        "Description": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__Description__resolve,
+        },
+        "ExpectedDuration": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: StageDetails__ExpectedDuration__resolve,
+        },
+        "Logs": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_Logs__type),
+            
+            Resolve: StageDetails__Logs__resolve,
+        },
+        "UpdatedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: StageDetails__UpdatedAt__resolve,
+        },
+    },
+})
+func Task__UUID__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldUUID().AsString()
+    
+}
+func Task__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStatus(), nil
+    
+}
+func Task__WorkedBy__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldWorkedBy()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__Stage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldStage().AsString()
+    
+}
+func Task__CurrentStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldCurrentStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__PastStageDetails__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldPastStageDetails()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__StartedAt__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStartedAt()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__RunCount__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldRunCount().AsInt()
+    
+}
+func Task__ErrorMessage__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldErrorMessage()
+    if f.Exists() {
+        
+        return f.Must().AsString()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__RetrievalTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldRetrievalTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+func Task__StorageTask__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.Task)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldStorageTask()
+    if f.Exists() {
+        
+        return f.Must(), nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var Task__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "Task",
+    Fields: graphql.Fields{
+        "UUID": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Task__UUID__resolve,
+        },
+        "Status": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Status__type),
+            
+            Resolve: Task__Status__resolve,
+        },
+        "WorkedBy": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: Task__WorkedBy__resolve,
+        },
+        "Stage": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.String),
+            
+            Resolve: Task__Stage__resolve,
+        },
+        "CurrentStageDetails": &graphql.Field{
+            
+            Type: StageDetails__type,
+            
+            Resolve: Task__CurrentStageDetails__resolve,
+        },
+        "PastStageDetails": &graphql.Field{
+            
+            Type: List_StageDetails__type,
+            
+            Resolve: Task__PastStageDetails__resolve,
+        },
+        "StartedAt": &graphql.Field{
+            
+            Type: Time__type,
+            
+            Resolve: Task__StartedAt__resolve,
+        },
+        "RunCount": &graphql.Field{
+            
+            Type: graphql.NewNonNull(graphql.Int),
+            
+            Resolve: Task__RunCount__resolve,
+        },
+        "ErrorMessage": &graphql.Field{
+            
+            Type: graphql.String,
+            
+            Resolve: Task__ErrorMessage__resolve,
+        },
+        "RetrievalTask": &graphql.Field{
+            
+            Type: RetrievalTask__type,
+            
+            Resolve: Task__RetrievalTask__resolve,
+        },
+        "StorageTask": &graphql.Field{
+            
+            Type: StorageTask__type,
+            
+            Resolve: Task__StorageTask__resolve,
+        },
+    },
+})
 func PopTask__Status__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.PopTask)
     if !ok {
@@ -1629,156 +1447,6 @@ var PopTask__type = graphql.NewObject(graphql.ObjectConfig{
             Type: graphql.NewNonNull(graphql.String),
             
             Resolve: PopTask__WorkedBy__resolve,
-        },
-    },
-})
-var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "List_AuthenticatedRecord",
-    Fields: graphql.Fields{
-        "At": &graphql.Field{
-            Type: AuthenticatedRecord__type,
-            Args: graphql.FieldConfigArgument{
-                "key": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-
-                arg := p.Args["key"]
-                var out ipld.Node
-                var err error
-                switch ta := arg.(type) {
-                case ipld.Node:
-                    out, err = ts.LookupByNode(ta)
-                case int64:
-                    out, err = ts.LookupByIndex(ta)
-                default:
-                    return nil, fmt.Errorf("unknown key type: %T", arg)
-                }
-                
-                return out, err
-                
-            },
-        },
-        "All": &graphql.Field{
-            Type: graphql.NewList(AuthenticatedRecord__type),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Range": &graphql.Field{
-            Type: graphql.NewList(AuthenticatedRecord__type),
-            Args: graphql.FieldConfigArgument{
-                "skip": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-                "take": &graphql.ArgumentConfig{
-                    Type: graphql.NewNonNull(graphql.Int),
-                },
-            },
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-                it := ts.ListIterator()
-                children := make([]ipld.Node, 0)
-
-                for !it.Done() {
-                    _, node, err := it.Next()
-                    if err != nil {
-                        return nil, err
-                    }
-                    
-                    children = append(children, node)
-                }
-                return children, nil	
-            },
-        },
-        "Count": &graphql.Field{
-            Type: graphql.NewNonNull(graphql.Int),
-            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
-                if !ok {
-                    return nil, errNotNode
-                }
-                return ts.Length(), nil
-            },
-        },
-    },
-})	
-func RecordUpdate__Records__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RecordUpdate)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldRecords(), nil
-    
-}
-func RecordUpdate__SigPrev__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RecordUpdate)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    return ts.FieldSigPrev(), nil
-    
-}
-func RecordUpdate__Previous__resolve(p graphql.ResolveParams) (interface{}, error) {
-    ts, ok := p.Source.(tasks.RecordUpdate)
-    if !ok {
-        return nil, errNotNode
-    }
-    
-    f := ts.FieldPrevious()
-    if f.Exists() {
-        
-        return "IS a link", nil
-        
-    } else {
-        return nil, nil
-    }
-    
-}
-var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
-    Name: "RecordUpdate",
-    Fields: graphql.Fields{
-        "Records": &graphql.Field{
-            
-            Type: graphql.NewNonNull(List_AuthenticatedRecord__type),
-            
-            Resolve: RecordUpdate__Records__resolve,
-        },
-        "SigPrev": &graphql.Field{
-            
-            Type: graphql.NewNonNull(Bytes__type),
-            
-            Resolve: RecordUpdate__SigPrev__resolve,
-        },
-        "Previous": &graphql.Field{
-            
-            Type: graphql.ID,
-            
-            Resolve: RecordUpdate__Previous__resolve,
         },
     },
 })
@@ -1975,6 +1643,352 @@ var List__type = graphql.NewObject(graphql.ObjectConfig{
         },
     },
 })	
+var List_Logs__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_Logs",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: Logs__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(Logs__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_Logs)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func AuthenticatedRecord__Record__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.AuthenticatedRecord)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    targetCid := ts.FieldRecord().Link()
+    
+			var node ipld.Node
+			
+	if cl, ok := targetCid.(cidlink.Link); ok {
+		v := p.Context.Value(nodeLoaderCtxKey)
+		if v == nil {
+			return cl.Cid, nil
+		}
+		loader, ok := v.(func(context.Context, cidlink.Link, ipld.NodeBuilder) (ipld.Node, error))
+		if !ok {
+			return nil, errInvalidLoader
+		}
+
+		builder := tasks.Type.FinishedTask__Repr.NewBuilder()
+		n, err := loader(p.Context, cl, builder);
+		if err != nil {
+			return nil, err
+		}
+		node = n
+	} else {
+		return nil, errInvalidLink
+	}
+	
+			return node, nil
+			
+    
+}
+func AuthenticatedRecord__Signature__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.AuthenticatedRecord)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSignature(), nil
+    
+}
+var AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "AuthenticatedRecord",
+    Fields: graphql.Fields{
+        "Record": &graphql.Field{
+            
+            Type: graphql.NewNonNull(FinishedTask__type),
+            
+            Resolve: AuthenticatedRecord__Record__resolve,
+        },
+        "Signature": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Bytes__type),
+            
+            Resolve: AuthenticatedRecord__Signature__resolve,
+        },
+    },
+})
+var List_AuthenticatedRecord__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "List_AuthenticatedRecord",
+    Fields: graphql.Fields{
+        "At": &graphql.Field{
+            Type: AuthenticatedRecord__type,
+            Args: graphql.FieldConfigArgument{
+                "key": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+
+                arg := p.Args["key"]
+                var out ipld.Node
+                var err error
+                switch ta := arg.(type) {
+                case ipld.Node:
+                    out, err = ts.LookupByNode(ta)
+                case int64:
+                    out, err = ts.LookupByIndex(ta)
+                default:
+                    return nil, fmt.Errorf("unknown key type: %T", arg)
+                }
+                
+                return out, err
+                
+            },
+        },
+        "All": &graphql.Field{
+            Type: graphql.NewList(AuthenticatedRecord__type),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Range": &graphql.Field{
+            Type: graphql.NewList(AuthenticatedRecord__type),
+            Args: graphql.FieldConfigArgument{
+                "skip": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+                "take": &graphql.ArgumentConfig{
+                    Type: graphql.NewNonNull(graphql.Int),
+                },
+            },
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                it := ts.ListIterator()
+                children := make([]ipld.Node, 0)
+
+                for !it.Done() {
+                    _, node, err := it.Next()
+                    if err != nil {
+                        return nil, err
+                    }
+                    
+                    children = append(children, node)
+                }
+                return children, nil	
+            },
+        },
+        "Count": &graphql.Field{
+            Type: graphql.NewNonNull(graphql.Int),
+            Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+                ts, ok := p.Source.(tasks.List_AuthenticatedRecord)
+                if !ok {
+                    return nil, errNotNode
+                }
+                return ts.Length(), nil
+            },
+        },
+    },
+})	
+func Status__type__serialize(value interface{}) interface{} {
+    switch value := value.(type) {
+    case ipld.Node:
+        
+        i, err := value.AsInt()
+        if err != nil {
+            return err
+        }
+        return i
+        
+    default:
+        return nil
+    }
+}
+func Status__type__parse(value interface{}) interface{} {
+    builder := tasks.Type.Status__Repr.NewBuilder()
+    switch v2 := value.(type) {
+    case string:
+        builder.AssignString(v2)
+    case *string:
+        builder.AssignString(*v2)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+func Status__type__parseLiteral(valueAST ast.Value) interface{} {
+    builder := tasks.Type.Status__Repr.NewBuilder()
+    switch valueAST := valueAST.(type) {
+    case *ast.StringValue:
+        builder.AssignString(valueAST.Value)
+    default:
+        return nil
+    }
+    return builder.Build()
+}
+var Status__type = graphql.NewScalar(graphql.ScalarConfig{
+    Name:        "Status",
+    Description: "Status",
+    Serialize: Status__type__serialize,
+    ParseValue: Status__type__parse,
+    ParseLiteral: Status__type__parseLiteral,
+})
+func RecordUpdate__Records__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldRecords(), nil
+    
+}
+func RecordUpdate__SigPrev__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    return ts.FieldSigPrev(), nil
+    
+}
+func RecordUpdate__Previous__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.RecordUpdate)
+    if !ok {
+        return nil, errNotNode
+    }
+    
+    f := ts.FieldPrevious()
+    if f.Exists() {
+        
+        return "IS a link", nil
+        
+    } else {
+        return nil, nil
+    }
+    
+}
+var RecordUpdate__type = graphql.NewObject(graphql.ObjectConfig{
+    Name: "RecordUpdate",
+    Fields: graphql.Fields{
+        "Records": &graphql.Field{
+            
+            Type: graphql.NewNonNull(List_AuthenticatedRecord__type),
+            
+            Resolve: RecordUpdate__Records__resolve,
+        },
+        "SigPrev": &graphql.Field{
+            
+            Type: graphql.NewNonNull(Bytes__type),
+            
+            Resolve: RecordUpdate__SigPrev__resolve,
+        },
+        "Previous": &graphql.Field{
+            
+            Type: graphql.ID,
+            
+            Resolve: RecordUpdate__Previous__resolve,
+        },
+    },
+})
 func Logs__Log__resolve(p graphql.ResolveParams) (interface{}, error) {
     ts, ok := p.Source.(tasks.Logs)
     if !ok {

--- a/controller/state/statedb_test.go
+++ b/controller/state/statedb_test.go
@@ -318,7 +318,11 @@ func TestUpdateTasks(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, *data.expectedStatus, task.Status)
-				require.Equal(t, data.expectedErrorMessage, task.ErrorMessage.String())
+				if data.expectedErrorMessage == "" {
+					require.False(t, task.ErrorMessage.Exists())
+				} else {
+					require.Equal(t, data.expectedErrorMessage, task.ErrorMessage.Must().String())
+				}
 				require.Equal(t, data.expectedStage, task.Stage.String())
 				if data.expectedStageDetails == nil {
 					require.Equal(t, task.CurrentStageDetails.Exists(), false)

--- a/tasks/client.go
+++ b/tasks/client.go
@@ -24,10 +24,16 @@ func (utp *_UpdateTask__Prototype) Of(workedBy string, status Status, runCount i
 }
 
 func (utp *_UpdateTask__Prototype) OfStage(workedBy string, status Status, errorMessage string, stage string, details StageDetails, runCount int) *_UpdateTask {
+	var err _String__Maybe
+	if errorMessage == "" {
+		err = _String__Maybe{m: schema.Maybe_Absent}
+	} else {
+		err = _String__Maybe{m: schema.Maybe_Value, v: &_String{errorMessage}}
+	}
 	ut := _UpdateTask{
 		WorkedBy:            _String{workedBy},
 		Status:              *status,
-		ErrorMessage:        _String__Maybe{m: schema.Maybe_Value, v: &_String{errorMessage}},
+		ErrorMessage:        err,
 		CurrentStageDetails: _StageDetails__Maybe{m: schema.Maybe_Value, v: details},
 		Stage:               _String__Maybe{m: schema.Maybe_Value, v: &_String{stage}},
 		RunCount:            _Int{int64(runCount)},

--- a/tasks/gen.go
+++ b/tasks/gen.go
@@ -112,7 +112,7 @@ func main() {
 		schema.SpawnStructField("PastStageDetails", "List_StageDetails", true, false),
 		schema.SpawnStructField("StartedAt", "Time", true, false),
 		schema.SpawnStructField("RunCount", "Int", false, false),
-		schema.SpawnStructField("ErrorMessage", "String", false, false),
+		schema.SpawnStructField("ErrorMessage", "String", true, false),
 		schema.SpawnStructField("RetrievalTask", "RetrievalTask", true, false),
 		schema.SpawnStructField("StorageTask", "StorageTask", true, false),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
@@ -121,7 +121,7 @@ func main() {
 	ts.Accumulate(schema.SpawnStruct("FinishedTask", []schema.StructField{
 		schema.SpawnStructField("Status", "Status", false, false),
 		schema.SpawnStructField("StartedAt", "Time", false, false),
-		schema.SpawnStructField("ErrorMessage", "String", false, false),
+		schema.SpawnStructField("ErrorMessage", "String", true, false),
 		schema.SpawnStructField("RetrievalTask", "RetrievalTask", true, false),
 		schema.SpawnStructField("StorageTask", "StorageTask", true, false),
 		schema.SpawnStructField("DealID", "Int", false, false),

--- a/tasks/ipldsch_satisfaction.go
+++ b/tasks/ipldsch_satisfaction.go
@@ -2507,7 +2507,7 @@ func (n _FinishedTask) FieldStatus() Status {
 func (n _FinishedTask) FieldStartedAt() Time {
 	return &n.StartedAt
 }
-func (n _FinishedTask) FieldErrorMessage() String {
+func (n _FinishedTask) FieldErrorMessage() MaybeString {
 	return &n.ErrorMessage
 }
 func (n _FinishedTask) FieldRetrievalTask() MaybeRetrievalTask {
@@ -2596,7 +2596,10 @@ func (n FinishedTask) LookupByString(key string) (ipld.Node, error) {
 	case "StartedAt":
 		return &n.StartedAt, nil
 	case "ErrorMessage":
-		return &n.ErrorMessage, nil
+		if n.ErrorMessage.m == schema.Maybe_Absent {
+			return ipld.Absent, nil
+		}
+		return n.ErrorMessage.v, nil
 	case "RetrievalTask":
 		if n.RetrievalTask.m == schema.Maybe_Absent {
 			return ipld.Absent, nil
@@ -2669,7 +2672,11 @@ func (itr *_FinishedTask__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 		v = &itr.n.StartedAt
 	case 2:
 		k = &fieldName__FinishedTask_ErrorMessage
-		v = &itr.n.ErrorMessage
+		if itr.n.ErrorMessage.m == schema.Maybe_Absent {
+			v = ipld.Absent
+			break
+		}
+		v = itr.n.ErrorMessage.v
 	case 3:
 		k = &fieldName__FinishedTask_RetrievalTask
 		if itr.n.RetrievalTask.m == schema.Maybe_Absent {
@@ -2833,7 +2840,7 @@ var (
 	fieldBit__FinishedTask_TimeToFirstByteMS = 1 << 9
 	fieldBit__FinishedTask_TimeToLastByteMS = 1 << 10
 	fieldBit__FinishedTask_Events = 1 << 11
-	fieldBits__FinishedTask_sufficient = 0 + 1 << 0 + 1 << 1 + 1 << 2 + 1 << 5 + 1 << 6 + 1 << 7 + 1 << 11
+	fieldBits__FinishedTask_sufficient = 0 + 1 << 0 + 1 << 1 + 1 << 5 + 1 << 6 + 1 << 7 + 1 << 11
 )
 func (na *_FinishedTask__Assembler) BeginMap(int64) (ipld.MapAssembler, error) {
 	switch *na.m {
@@ -2947,10 +2954,9 @@ func (ma *_FinishedTask__Assembler) valueFinishTidy() bool {
 			return false
 		}
 	case 2:
-		switch ma.cm {
+		switch ma.w.ErrorMessage.m {
 		case schema.Maybe_Value:
-			ma.ca_ErrorMessage.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.ErrorMessage.v = ma.ca_ErrorMessage.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -3088,8 +3094,8 @@ func (ma *_FinishedTask__Assembler) AssembleEntry(k string) (ipld.NodeAssembler,
 		ma.s += fieldBit__FinishedTask_ErrorMessage
 		ma.state = maState_midValue
 		ma.f = 2
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
 		return &ma.ca_ErrorMessage, nil
 	case "RetrievalTask":
 		if ma.s & fieldBit__FinishedTask_RetrievalTask != 0 {
@@ -3227,8 +3233,8 @@ func (ma *_FinishedTask__Assembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_StartedAt.m = &ma.cm
 		return &ma.ca_StartedAt
 	case 2:
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
 		return &ma.ca_ErrorMessage
 	case 3:
 		ma.ca_RetrievalTask.w = ma.w.RetrievalTask.v
@@ -3292,9 +3298,6 @@ func (ma *_FinishedTask__Assembler) Finish() error {
 		}
 		if ma.s & fieldBit__FinishedTask_StartedAt == 0 {
 			err.Missing = append(err.Missing, "StartedAt")
-		}
-		if ma.s & fieldBit__FinishedTask_ErrorMessage == 0 {
-			err.Missing = append(err.Missing, "ErrorMessage")
 		}
 		if ma.s & fieldBit__FinishedTask_DealID == 0 {
 			err.Missing = append(err.Missing, "DealID")
@@ -3481,7 +3484,10 @@ func (n *_FinishedTask__Repr) LookupByString(key string) (ipld.Node, error) {
 	case "StartedAt":
 		return n.StartedAt.Representation(), nil
 	case "ErrorMessage":
-		return n.ErrorMessage.Representation(), nil
+		if n.ErrorMessage.m == schema.Maybe_Absent {
+			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+		}
+		return n.ErrorMessage.v.Representation(), nil
 	case "RetrievalTask":
 		if n.RetrievalTask.m == schema.Maybe_Absent {
 			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
@@ -3555,7 +3561,11 @@ advance:if itr.idx >= 12 {
 		v = itr.n.StartedAt.Representation()
 	case 2:
 		k = &fieldName__FinishedTask_ErrorMessage_serial
-		v = itr.n.ErrorMessage.Representation()
+		if itr.n.ErrorMessage.m == schema.Maybe_Absent {
+			itr.idx++
+			goto advance
+		}
+		v = itr.n.ErrorMessage.v.Representation()
 	case 3:
 		k = &fieldName__FinishedTask_RetrievalTask_serial
 		if itr.n.RetrievalTask.m == schema.Maybe_Absent {
@@ -3617,6 +3627,9 @@ func (_FinishedTask__Repr) ListIterator() ipld.ListIterator {
 }
 func (rn *_FinishedTask__Repr) Length() int64 {
 	l := 12
+	if rn.ErrorMessage.m == schema.Maybe_Absent {
+		l--
+	}
 	if rn.RetrievalTask.m == schema.Maybe_Absent {
 		l--
 	}
@@ -3828,8 +3841,9 @@ func (ma *_FinishedTask__ReprAssembler) valueFinishTidy() bool {
 			return false
 		}
 	case 2:
-		switch ma.cm {
-		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+		switch ma.w.ErrorMessage.m {
+		case schema.Maybe_Value:
+			ma.w.ErrorMessage.v = ma.ca_ErrorMessage.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -3959,8 +3973,9 @@ func (ma *_FinishedTask__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssemb
 		ma.s += fieldBit__FinishedTask_ErrorMessage
 		ma.state = maState_midValue
 		ma.f = 2
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
+		
 		return &ma.ca_ErrorMessage, nil
 	case "RetrievalTask":
 		if ma.s & fieldBit__FinishedTask_RetrievalTask != 0 {
@@ -4103,8 +4118,9 @@ func (ma *_FinishedTask__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_StartedAt.m = &ma.cm
 		return &ma.ca_StartedAt
 	case 2:
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
+		
 		return &ma.ca_ErrorMessage
 	case 3:
 		ma.ca_RetrievalTask.w = ma.w.RetrievalTask.v
@@ -4173,9 +4189,6 @@ func (ma *_FinishedTask__ReprAssembler) Finish() error {
 		}
 		if ma.s & fieldBit__FinishedTask_StartedAt == 0 {
 			err.Missing = append(err.Missing, "StartedAt")
-		}
-		if ma.s & fieldBit__FinishedTask_ErrorMessage == 0 {
-			err.Missing = append(err.Missing, "ErrorMessage")
 		}
 		if ma.s & fieldBit__FinishedTask_DealID == 0 {
 			err.Missing = append(err.Missing, "DealID")
@@ -15557,7 +15570,7 @@ func (n _Task) FieldStartedAt() MaybeTime {
 func (n _Task) FieldRunCount() Int {
 	return &n.RunCount
 }
-func (n _Task) FieldErrorMessage() String {
+func (n _Task) FieldErrorMessage() MaybeString {
 	return &n.ErrorMessage
 }
 func (n _Task) FieldRetrievalTask() MaybeRetrievalTask {
@@ -15648,7 +15661,10 @@ func (n Task) LookupByString(key string) (ipld.Node, error) {
 	case "RunCount":
 		return &n.RunCount, nil
 	case "ErrorMessage":
-		return &n.ErrorMessage, nil
+		if n.ErrorMessage.m == schema.Maybe_Absent {
+			return ipld.Absent, nil
+		}
+		return n.ErrorMessage.v, nil
 	case "RetrievalTask":
 		if n.RetrievalTask.m == schema.Maybe_Absent {
 			return ipld.Absent, nil
@@ -15732,7 +15748,11 @@ func (itr *_Task__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 		v = &itr.n.RunCount
 	case 8:
 		k = &fieldName__Task_ErrorMessage
-		v = &itr.n.ErrorMessage
+		if itr.n.ErrorMessage.m == schema.Maybe_Absent {
+			v = ipld.Absent
+			break
+		}
+		v = itr.n.ErrorMessage.v
 	case 9:
 		k = &fieldName__Task_RetrievalTask
 		if itr.n.RetrievalTask.m == schema.Maybe_Absent {
@@ -15860,7 +15880,7 @@ var (
 	fieldBit__Task_ErrorMessage = 1 << 8
 	fieldBit__Task_RetrievalTask = 1 << 9
 	fieldBit__Task_StorageTask = 1 << 10
-	fieldBits__Task_sufficient = 0 + 1 << 0 + 1 << 1 + 1 << 3 + 1 << 7 + 1 << 8
+	fieldBits__Task_sufficient = 0 + 1 << 0 + 1 << 1 + 1 << 3 + 1 << 7
 )
 func (na *_Task__Assembler) BeginMap(int64) (ipld.MapAssembler, error) {
 	switch *na.m {
@@ -16030,10 +16050,9 @@ func (ma *_Task__Assembler) valueFinishTidy() bool {
 			return false
 		}
 	case 8:
-		switch ma.cm {
+		switch ma.w.ErrorMessage.m {
 		case schema.Maybe_Value:
-			ma.ca_ErrorMessage.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.ErrorMessage.v = ma.ca_ErrorMessage.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -16164,8 +16183,8 @@ func (ma *_Task__Assembler) AssembleEntry(k string) (ipld.NodeAssembler, error) 
 		ma.s += fieldBit__Task_ErrorMessage
 		ma.state = maState_midValue
 		ma.f = 8
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
 		return &ma.ca_ErrorMessage, nil
 	case "RetrievalTask":
 		if ma.s & fieldBit__Task_RetrievalTask != 0 {
@@ -16257,8 +16276,8 @@ func (ma *_Task__Assembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_RunCount.m = &ma.cm
 		return &ma.ca_RunCount
 	case 8:
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
 		return &ma.ca_ErrorMessage
 	case 9:
 		ma.ca_RetrievalTask.w = ma.w.RetrievalTask.v
@@ -16300,9 +16319,6 @@ func (ma *_Task__Assembler) Finish() error {
 		}
 		if ma.s & fieldBit__Task_RunCount == 0 {
 			err.Missing = append(err.Missing, "RunCount")
-		}
-		if ma.s & fieldBit__Task_ErrorMessage == 0 {
-			err.Missing = append(err.Missing, "ErrorMessage")
 		}
 		return err
 	}
@@ -16493,7 +16509,10 @@ func (n *_Task__Repr) LookupByString(key string) (ipld.Node, error) {
 	case "RunCount":
 		return n.RunCount.Representation(), nil
 	case "ErrorMessage":
-		return n.ErrorMessage.Representation(), nil
+		if n.ErrorMessage.m == schema.Maybe_Absent {
+			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+		}
+		return n.ErrorMessage.v.Representation(), nil
 	case "RetrievalTask":
 		if n.RetrievalTask.m == schema.Maybe_Absent {
 			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
@@ -16530,6 +16549,11 @@ func (n *_Task__Repr) MapIterator() ipld.MapIterator {
 	}
 	if n.RetrievalTask.m == schema.Maybe_Absent {
 		end = 9
+	} else {
+		goto done
+	}
+	if n.ErrorMessage.m == schema.Maybe_Absent {
+		end = 8
 	} else {
 		goto done
 	}
@@ -16590,7 +16614,11 @@ advance:if itr.idx >= 11 {
 		v = itr.n.RunCount.Representation()
 	case 8:
 		k = &fieldName__Task_ErrorMessage_serial
-		v = itr.n.ErrorMessage.Representation()
+		if itr.n.ErrorMessage.m == schema.Maybe_Absent {
+			itr.idx++
+			goto advance
+		}
+		v = itr.n.ErrorMessage.v.Representation()
 	case 9:
 		k = &fieldName__Task_RetrievalTask_serial
 		if itr.n.RetrievalTask.m == schema.Maybe_Absent {
@@ -16629,6 +16657,9 @@ func (rn *_Task__Repr) Length() int64 {
 		l--
 	}
 	if rn.StartedAt.m == schema.Maybe_Absent {
+		l--
+	}
+	if rn.ErrorMessage.m == schema.Maybe_Absent {
 		l--
 	}
 	if rn.RetrievalTask.m == schema.Maybe_Absent {
@@ -16883,8 +16914,9 @@ func (ma *_Task__ReprAssembler) valueFinishTidy() bool {
 			return false
 		}
 	case 8:
-		switch ma.cm {
-		case schema.Maybe_Value:ma.cm = schema.Maybe_Absent
+		switch ma.w.ErrorMessage.m {
+		case schema.Maybe_Value:
+			ma.w.ErrorMessage.v = ma.ca_ErrorMessage.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -17019,8 +17051,9 @@ func (ma *_Task__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssembler, err
 		ma.s += fieldBit__Task_ErrorMessage
 		ma.state = maState_midValue
 		ma.f = 8
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
+		
 		return &ma.ca_ErrorMessage, nil
 	case "RetrievalTask":
 		if ma.s & fieldBit__Task_RetrievalTask != 0 {
@@ -17118,8 +17151,9 @@ func (ma *_Task__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_RunCount.m = &ma.cm
 		return &ma.ca_RunCount
 	case 8:
-		ma.ca_ErrorMessage.w = &ma.w.ErrorMessage
-		ma.ca_ErrorMessage.m = &ma.cm
+		ma.ca_ErrorMessage.w = ma.w.ErrorMessage.v
+		ma.ca_ErrorMessage.m = &ma.w.ErrorMessage.m
+		
 		return &ma.ca_ErrorMessage
 	case 9:
 		ma.ca_RetrievalTask.w = ma.w.RetrievalTask.v
@@ -17163,9 +17197,6 @@ func (ma *_Task__ReprAssembler) Finish() error {
 		}
 		if ma.s & fieldBit__Task_RunCount == 0 {
 			err.Missing = append(err.Missing, "RunCount")
-		}
-		if ma.s & fieldBit__Task_ErrorMessage == 0 {
-			err.Missing = append(err.Missing, "ErrorMessage")
 		}
 		return err
 	}

--- a/tasks/ipldsch_types.go
+++ b/tasks/ipldsch_types.go
@@ -114,7 +114,7 @@ type FinishedTask = *_FinishedTask
 type _FinishedTask struct {
 	Status _Status
 	StartedAt _Time
-	ErrorMessage _String
+	ErrorMessage _String__Maybe
 	RetrievalTask _RetrievalTask__Maybe
 	StorageTask _StorageTask__Maybe
 	DealID _Int
@@ -254,7 +254,7 @@ type _Task struct {
 	PastStageDetails _List_StageDetails__Maybe
 	StartedAt _Time__Maybe
 	RunCount _Int
-	ErrorMessage _String
+	ErrorMessage _String__Maybe
 	RetrievalTask _RetrievalTask__Maybe
 	StorageTask _StorageTask__Maybe
 }


### PR DESCRIPTION
# Goals

Make old data compatible by making the error message and optional field

# Implementation

- Make the error message field on task and finalize task optional.
- Also, combine Update & UpdateTasks methods -- simplifies a
lot
- also, since it's an optional field, when the error message is blank, actually make the field absent.