### PR TITLE
Add miner flag to queue-storage

### DIFF
--- a/commands/queue_storage.go
+++ b/commands/queue_storage.go
@@ -13,7 +13,7 @@ import (
 var QueueStorageCmd = &cli.Command{
 	Name:   "queue-storage",
 	Usage:  "Queue storage deal in the controller",
-	Flags:  append(EndpointFlags, StorageFlags...),
+	Flags:  append(append(EndpointFlags, MinerFlags...), StorageFlags...),
 	Action: queueStorageDeal,
 }
 


### PR DESCRIPTION
queue-storage expects a miner but it's not currently in the flag list

note: discovered using dealbot -- not sure when this broke, fixing now