### PR TITLE
Fix bugs discovered using dealbot

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -166,7 +166,7 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task, runCount, worker 
 
 	// Define function to update task stage.  Use shutdown context, not task
 	updateStage := func(stage string, stageDetails tasks.StageDetails) error {
-		task, err = e.client.UpdateTask(ctx, task.UUID.String(),
+		updatedTask, err := e.client.UpdateTask(ctx, task.UUID.String(),
 			tasks.Type.UpdateTask.OfStage(
 				e.host,
 				tasks.InProgress,
@@ -175,6 +175,11 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task, runCount, worker 
 				stageDetails,
 				runCount,
 			))
+		// TODO: this is a weird side-effecty behavior and we should find a way
+		// to remove it
+		if err == nil {
+			task = updatedTask
+		}
 		return err
 	}
 

--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -37,3 +37,72 @@ func TestRunEndJob(t *testing.T) {
 		t.Fatal("job should have ended")
 	}
 }
+
+func TestQueue(t *testing.T) {
+	runChan := make(chan Job)
+
+	jobInternal := &job{
+		entryID: 42,
+		runTime: time.Minute,
+		runChan: runChan,
+	}
+
+	queueDone := make(chan struct{})
+	jobDone := make(chan struct{})
+	go func() {
+		jobInternal.Queue(func() {
+			close(jobDone)
+		})
+		close(queueDone)
+	}()
+
+	var j Job
+
+	time.Sleep(time.Second)
+	select {
+	case <-queueDone:
+		t.Fatal("should not finish queue until run chan is read")
+	default:
+	}
+	select {
+	case <-jobDone:
+		t.Fatal("done callback not called till job is finished")
+	default:
+	}
+
+	select {
+	case j = <-runChan:
+	case <-time.After(time.Second):
+		t.Fatal("job should have started")
+	}
+
+	select {
+	case <-queueDone:
+	case <-time.After(time.Second):
+		t.Fatal("job should have finished queueing")
+	}
+	select {
+	case <-jobDone:
+		t.Fatal("done callback not called till job is finished")
+	default:
+	}
+	select {
+	case <-j.Context.Done():
+		t.Fatal("job should not have ended")
+	default:
+	}
+
+	j.End()
+
+	select {
+	case <-j.Context.Done():
+	default:
+		t.Fatal("job should have ended")
+	}
+
+	select {
+	case <-jobDone:
+	case <-time.After(time.Second):
+		t.Fatal("job should have ended")
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -70,7 +70,7 @@ func (s *Scheduler) Add(cronExp string, task tasks.Task, maxRunTime, scheduleLim
 		shutdown:   s.shutdown,
 	}
 	if cronExp == RunNow {
-		go j.Run()
+		j.Queue(func() {})
 		return noEnt, nil
 	}
 	if scheduleLimit != 0 {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -70,7 +70,7 @@ func (s *Scheduler) Add(cronExp string, task tasks.Task, maxRunTime, scheduleLim
 		shutdown:   s.shutdown,
 	}
 	if cronExp == RunNow {
-		j.Run()
+		go j.Run()
 		return noEnt, nil
 	}
 	if scheduleLimit != 0 {


### PR DESCRIPTION
# Goals

These are two bugs discovered during using dealbot:
- Immediately running jobs block the scheduler currently, causing a loss of parallelism
- If there is a network error in a controller update, the end of the job has a nil pointer exception

# Implementation

- For the nil pointer exception, don't overwrite the task to nil in engine.go when there is an error during updating the task status
- For the scheduler:
   - when executing via chron, we want to wait till the job is all the way done
   - when executing immediately, we only want to wait till a worker picks up the job
   - so, make a queue function that returns as soon as the job gets queued, but takes a callback that only gets executed when the job is done
   - use queue with callback that does nothing for immediate jobs
   - use callback to block till job is over for chron runs