### PR TITLE
Stage timeouts

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -53,6 +53,11 @@ var RetrievalFlags = []cli.Flag{
 		Usage: "payload cid to fetch from miner",
 		Value: "bafykbzacedikkmeotawrxqquthryw3cijaonobygdp7fb5bujhuos6wdkwomm",
 	},
+	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		Name:    "stage-timeout",
+		Usage:   "stagename=duration exampple: DealAccepted=30m",
+		EnvVars: []string{"STAGE_TIMEOUT"},
+	}),
 }
 
 var StorageFlags = []cli.Flag{
@@ -89,6 +94,11 @@ var StorageFlags = []cli.Flag{
 		EnvVars: []string{"DEALBOT_START_OFFSET"},
 		Value:   30760,
 	},
+	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		Name:    "stage-timeout",
+		Usage:   "stagename=duration exampple: DealAccepted=30m",
+		EnvVars: []string{"STAGE_TIMEOUT"},
+	}),
 }
 
 var SingleTaskFlags = append(DealFlags, MinerFlags...)
@@ -125,6 +135,11 @@ var DaemonFlags = append(DealFlags, append(CommonFlags, append(EndpointFlags, []
 		Name:    "tags",
 		Usage:   "comma separated tag strings",
 		EnvVars: []string{"DEALBOT_TAGS"},
+	}),
+	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		Name:    "stage-timeout",
+		Usage:   "stagename=duration exampple: DealAccepted=30m",
+		EnvVars: []string{"STAGE_TIMEOUT"},
 	}),
 }...)...)...)
 

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -55,7 +55,7 @@ var RetrievalFlags = []cli.Flag{
 	},
 	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 		Name:    "stage-timeout",
-		Usage:   "stagename=duration (example: DealAccepted=15m), set default: default=30m",
+		Usage:   "stagename=duration (example: DealAccepted=15m), DefaultRetrieval sets default",
 		EnvVars: []string{"STAGE_TIMEOUT"},
 	}),
 }
@@ -94,6 +94,11 @@ var StorageFlags = []cli.Flag{
 		EnvVars: []string{"DEALBOT_START_OFFSET"},
 		Value:   30760,
 	},
+	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		Name:    "stage-timeout",
+		Usage:   "stagename=duration (example: ProposeDeal=15m), DefaultStorage sets default",
+		EnvVars: []string{"STAGE_TIMEOUT"},
+	}),
 }
 
 var SingleTaskFlags = append(DealFlags, MinerFlags...)
@@ -122,7 +127,7 @@ var DaemonFlags = append(DealFlags, append(CommonFlags, append(EndpointFlags, []
 	}),
 	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 		Name:    "stage-timeout",
-		Usage:   "stagename=duration (example: DealAccepted=15m), set default: default=30m",
+		Usage:   "stagename=duration (example: DealAccepted=15m), DefaultRetrieval and DefaultStorage set defaults",
 		EnvVars: []string{"STAGE_TIMEOUT"},
 	}),
 	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -55,7 +55,7 @@ var RetrievalFlags = []cli.Flag{
 	},
 	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 		Name:    "stage-timeout",
-		Usage:   "stagename=duration exampple: DealAccepted=30m",
+		Usage:   "stagename=duration (example: DealAccepted=15m), set default: default=30m",
 		EnvVars: []string{"STAGE_TIMEOUT"},
 	}),
 }
@@ -120,21 +120,21 @@ var DaemonFlags = append(DealFlags, append(CommonFlags, append(EndpointFlags, []
 		Aliases: []string{"l"},
 		EnvVars: []string{"DEALBOT_LISTEN"},
 	}),
-	altsrc.NewIntFlag(&cli.IntFlag{
-		Name:    "workers",
-		Usage:   "number of concurrent task workers",
-		EnvVars: []string{"DEALBOT_WORKERS"},
-		Value:   1,
+	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		Name:    "stage-timeout",
+		Usage:   "stagename=duration (example: DealAccepted=15m), set default: default=30m",
+		EnvVars: []string{"STAGE_TIMEOUT"},
 	}),
 	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 		Name:    "tags",
 		Usage:   "comma separated tag strings",
 		EnvVars: []string{"DEALBOT_TAGS"},
 	}),
-	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
-		Name:    "stage-timeout",
-		Usage:   "stagename=duration exampple: DealAccepted=30m",
-		EnvVars: []string{"STAGE_TIMEOUT"},
+	altsrc.NewIntFlag(&cli.IntFlag{
+		Name:    "workers",
+		Usage:   "number of concurrent task workers",
+		EnvVars: []string{"DEALBOT_WORKERS"},
+		Value:   1,
 	}),
 }...)...)...)
 

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -94,11 +94,6 @@ var StorageFlags = []cli.Flag{
 		EnvVars: []string{"DEALBOT_START_OFFSET"},
 		Value:   30760,
 	},
-	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
-		Name:    "stage-timeout",
-		Usage:   "stagename=duration exampple: DealAccepted=30m",
-		EnvVars: []string{"STAGE_TIMEOUT"},
-	}),
 }
 
 var SingleTaskFlags = append(DealFlags, MinerFlags...)

--- a/commands/retrieval_deal.go
+++ b/commands/retrieval_deal.go
@@ -37,12 +37,12 @@ func makeRetrievalDeal(cctx *cli.Context) error {
 	// get miner address
 	minerParam := cctx.String("miner")
 
-	task := tasks.Type.RetrievalTask.Of(minerParam, payloadCid, carExport, "")
-
 	stageTimeouts, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
 	if err != nil {
 		return err
 	}
+
+	task := tasks.Type.RetrievalTask.Of(minerParam, payloadCid, carExport, "")
 
 	err = tasks.MakeRetrievalDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow, stageTimeouts)
 	if err != nil {
@@ -54,6 +54,6 @@ func makeRetrievalDeal(cctx *cli.Context) error {
 	return nil
 }
 
-func emptyUpdateStage(string, tasks.StageDetails) error {
+func emptyUpdateStage(context.Context, string, tasks.StageDetails) error {
 	return nil
 }

--- a/commands/retrieval_deal.go
+++ b/commands/retrieval_deal.go
@@ -39,7 +39,12 @@ func makeRetrievalDeal(cctx *cli.Context) error {
 
 	task := tasks.Type.RetrievalTask.Of(minerParam, payloadCid, carExport, "")
 
-	err = tasks.MakeRetrievalDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow)
+	stageTimeouts, _, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
+	if err != nil {
+		return err
+	}
+
+	err = tasks.MakeRetrievalDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow, stageTimeouts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/retrieval_deal.go
+++ b/commands/retrieval_deal.go
@@ -39,7 +39,7 @@ func makeRetrievalDeal(cctx *cli.Context) error {
 
 	task := tasks.Type.RetrievalTask.Of(minerParam, payloadCid, carExport, "")
 
-	stageTimeouts, _, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
+	stageTimeouts, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
 	if err != nil {
 		return err
 	}

--- a/commands/storage_deal.go
+++ b/commands/storage_deal.go
@@ -40,10 +40,5 @@ func makeStorageDeal(cctx *cli.Context) error {
 
 	task := tasks.Type.StorageTask.Of(miner, int64(maxPrice), int64(size.Bytes()), int64(startOffset), fastRetrieval, verified, "")
 
-	_, stageTimeouts, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
-	if err != nil {
-		return err
-	}
-
-	return tasks.MakeStorageDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow, stageTimeouts)
+	return tasks.MakeStorageDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow)
 }

--- a/commands/storage_deal.go
+++ b/commands/storage_deal.go
@@ -40,5 +40,10 @@ func makeStorageDeal(cctx *cli.Context) error {
 
 	task := tasks.Type.StorageTask.Of(miner, int64(maxPrice), int64(size.Bytes()), int64(startOffset), fastRetrieval, verified, "")
 
-	return tasks.MakeStorageDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow)
+	_, stageTimeouts, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
+	if err != nil {
+		return err
+	}
+
+	return tasks.MakeStorageDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow, stageTimeouts)
 }

--- a/commands/storage_deal.go
+++ b/commands/storage_deal.go
@@ -38,7 +38,12 @@ func makeStorageDeal(cctx *cli.Context) error {
 	startOffset := cctx.Uint64("start-offset")
 	maxPrice := cctx.Uint64("max-price")
 
+	stageTimeouts, err := tasks.ParseStageTimeouts(cctx.StringSlice("stage-timeout"))
+	if err != nil {
+		return err
+	}
+
 	task := tasks.Type.StorageTask.Of(miner, int64(maxPrice), int64(size.Bytes()), int64(startOffset), fastRetrieval, verified, "")
 
-	return tasks.MakeStorageDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow)
+	return tasks.MakeStorageDeal(cctx.Context, nodeConfig, node, task, emptyUpdateStage, log.Infow, stageTimeouts)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -20,6 +20,9 @@ const (
 	maxTaskRunTime = 24 * time.Hour
 	noTasksWait    = 5 * time.Second
 	popTaskTimeout = 2 * time.Second
+
+	defaultProposeRetrievalTimeout = 30 * time.Minute
+	defaultDealAcceptedTimeout     = 30 * time.Minute
 )
 
 var log = logging.Logger("engine")
@@ -35,6 +38,8 @@ type Engine struct {
 	shutdown   chan struct{}
 	stopped    chan struct{}
 	tags       []string
+
+	statusTimeouts map[string]time.Duration
 }
 
 func New(ctx context.Context, cliCtx *cli.Context) (*Engine, error) {
@@ -58,6 +63,12 @@ func New(ctx context.Context, cliCtx *cli.Context) (*Engine, error) {
 	v, err := node.Version(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Establish default timeouts
+	stageTimeouts := map[string]time.Duration{
+		"ProposeRetrieval": defaultProposeRetrievalTimeout,
+		"DealAccepted":     defaultDealAcceptedTimeout,
 	}
 
 	log.Infof("remote version: %s", v.Version)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -180,7 +180,7 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task, runCount, worker 
 	log.Infow("worker running task", "uuid", task.UUID.String(), "run_count", runCount, "worker_id", worker)
 
 	// Define function to update task stage.  Use shutdown context, not task
-	updateStage := func(stage string, stageDetails tasks.StageDetails) error {
+	updateStage := func(ctx context.Context, stage string, stageDetails tasks.StageDetails) error {
 		updatedTask, err := e.client.UpdateTask(ctx, task.UUID.String(),
 			tasks.Type.UpdateTask.OfStage(
 				e.host,
@@ -218,7 +218,7 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task, runCount, worker 
 			tlog.Info("successfully retrieved data")
 		}
 	} else if task.StorageTask.Exists() {
-		err = tasks.MakeStorageDeal(ctx, e.nodeConfig, e.node, task.StorageTask.Must(), updateStage, log.Infow)
+		err = tasks.MakeStorageDeal(ctx, e.nodeConfig, e.node, task.StorageTask.Must(), updateStage, log.Infow, e.stageTimeouts)
 		if err != nil {
 			if err == context.Canceled {
 				// Engine closed, do not update final state

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -206,39 +206,36 @@ func (rp *_RetrievalTask__Prototype) Of(minerParam string, payloadCid string, ca
 	return &rt
 }
 
-// ParseStageTimeouts parses "StageName=timeout" strings into maps of retrieval and
-// storage timeouts.
-func ParseStageTimeouts(timeoutSpecs []string) (map[string]time.Duration, map[string]time.Duration, error) {
-	var (
-		retrievalTimeouts map[string]time.Duration
-		storageTimeouts   map[string]time.Duration
-	)
+// ParseStageTimeouts parses "StageName=timeout" strings into a map of stage
+// name to timeout duration.
+func ParseStageTimeouts(timeoutSpecs []string) (map[string]time.Duration, error) {
+	var stageTimeouts map[string]time.Duration
 
 	// Parse all stage timeout durations
-	stageTimeouts := map[string]time.Duration{}
+	timeouts := map[string]time.Duration{}
 	for _, spec := range timeoutSpecs {
 		parts := strings.SplitN(spec, "=", 2)
 		if len(parts) != 2 {
-			return nil, nil, fmt.Errorf("invalid stage timeout specification: %s", spec)
+			return nil, fmt.Errorf("invalid stage timeout specification: %s", spec)
 		}
 		stage := parts[0]
 		timeout := parts[1]
 		d, err := time.ParseDuration(strings.TrimSpace(timeout))
 		if err != nil || d < time.Second {
-			return nil, nil, fmt.Errorf("invalid value for stage %q timeout: %s", stage, timeout)
+			return nil, fmt.Errorf("invalid value for stage %q timeout: %s", stage, timeout)
 		}
-		stageTimeouts[strings.ToLower(strings.TrimSpace(stage))] = d
+		timeouts[strings.ToLower(strings.TrimSpace(stage))] = d
 	}
 
 	// Get retrieval timeouts
 	for stageName, _ := range RetrievalStages {
 		stageName = strings.ToLower(stageName)
-		d, ok := stageTimeouts[stageName]
+		d, ok := timeouts[stageName]
 		if ok {
-			if retrievalTimeouts == nil {
-				retrievalTimeouts = make(map[string]time.Duration)
+			if stageTimeouts == nil {
+				stageTimeouts = make(map[string]time.Duration)
 			}
-			retrievalTimeouts[stageName] = d
+			stageTimeouts[stageName] = d
 		}
 	}
 
@@ -246,5 +243,5 @@ func ParseStageTimeouts(timeoutSpecs []string) (map[string]time.Duration, map[st
 	//
 	// None defined currently
 
-	return retrievalTimeouts, storageTimeouts, nil
+	return stageTimeouts, nil
 }

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -243,7 +243,15 @@ func ParseStageTimeouts(timeoutSpecs []string) (map[string]time.Duration, error)
 	stageTimeouts := make(map[string]time.Duration, len(timeouts)+1)
 	stageTimeouts[defaultStageTimeoutName] = d
 
-	// Get retrieval timeouts
+	// Get common stage timeouts
+	for stageName, _ := range CommonStages {
+		stageName = strings.ToLower(stageName)
+		if d, ok = timeouts[stageName]; ok {
+			stageTimeouts[stageName] = d
+		}
+	}
+
+	// Get retrieval stage timeouts
 	for stageName, _ := range RetrievalStages {
 		stageName = strings.ToLower(stageName)
 		if d, ok = timeouts[stageName]; ok {

--- a/tasks/retrieval_deal_test.go
+++ b/tasks/retrieval_deal_test.go
@@ -1,0 +1,52 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseStageTimeouts(t *testing.T) {
+	retTo, stoTo, err := ParseStageTimeouts([]string{"ProposeRetrieval=31m", "DealAccepted=3h"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stoTo != nil {
+		t.Error("not expecteing storage timeouts")
+	}
+	if len(retTo) != 2 {
+		t.Fatal("expected 2 retrieval timeouts")
+	}
+	to, ok := retTo["proposeretrieval"]
+	if !ok {
+		t.Fatal("missing proposeretrieval timeout")
+	}
+	if to != 31*time.Minute {
+		t.Error("wrong value for proposeretrieval timeout")
+	}
+
+	to, ok = retTo["dealaccepted"]
+	if !ok {
+		t.Fatal("missing dealaccepted timeout")
+	}
+	if to != 3*time.Hour {
+		t.Error("wrong value for dealaccepted timeout")
+	}
+
+	retTo, _, err = ParseStageTimeouts([]string{"DealAccepted=3x"})
+	if err == nil {
+		t.Fatal("expected error from bad duration value")
+	}
+
+	retTo, _, err = ParseStageTimeouts([]string{"DealAccepted:3h"})
+	if err == nil {
+		t.Fatal("expected error from bad specification")
+	}
+
+	retTo, _, err = ParseStageTimeouts([]string{"unknown=3h"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retTo != nil {
+		t.Fatal("should not have retrieval timeouts")
+	}
+}

--- a/tasks/retrieval_deal_test.go
+++ b/tasks/retrieval_deal_test.go
@@ -6,17 +6,14 @@ import (
 )
 
 func TestParseStageTimeouts(t *testing.T) {
-	retTo, stoTo, err := ParseStageTimeouts([]string{"ProposeRetrieval=31m", "DealAccepted=3h"})
+	stageTo, err := ParseStageTimeouts([]string{"ProposeRetrieval=31m", "DealAccepted=3h"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stoTo != nil {
-		t.Error("not expecteing storage timeouts")
-	}
-	if len(retTo) != 2 {
+	if len(stageTo) != 2 {
 		t.Fatal("expected 2 retrieval timeouts")
 	}
-	to, ok := retTo["proposeretrieval"]
+	to, ok := stageTo["proposeretrieval"]
 	if !ok {
 		t.Fatal("missing proposeretrieval timeout")
 	}
@@ -24,7 +21,7 @@ func TestParseStageTimeouts(t *testing.T) {
 		t.Error("wrong value for proposeretrieval timeout")
 	}
 
-	to, ok = retTo["dealaccepted"]
+	to, ok = stageTo["dealaccepted"]
 	if !ok {
 		t.Fatal("missing dealaccepted timeout")
 	}
@@ -32,21 +29,21 @@ func TestParseStageTimeouts(t *testing.T) {
 		t.Error("wrong value for dealaccepted timeout")
 	}
 
-	retTo, _, err = ParseStageTimeouts([]string{"DealAccepted=3x"})
+	stageTo, err = ParseStageTimeouts([]string{"DealAccepted=3x"})
 	if err == nil {
 		t.Fatal("expected error from bad duration value")
 	}
 
-	retTo, _, err = ParseStageTimeouts([]string{"DealAccepted:3h"})
+	stageTo, err = ParseStageTimeouts([]string{"DealAccepted:3h"})
 	if err == nil {
 		t.Fatal("expected error from bad specification")
 	}
 
-	retTo, _, err = ParseStageTimeouts([]string{"unknown=3h"})
+	stageTo, err = ParseStageTimeouts([]string{"unknown=3h"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if retTo != nil {
+	if stageTo != nil {
 		t.Fatal("should not have retrieval timeouts")
 	}
 }

--- a/tasks/retrieval_deal_test.go
+++ b/tasks/retrieval_deal_test.go
@@ -6,19 +6,19 @@ import (
 )
 
 func TestParseStageTimeouts(t *testing.T) {
-	stageTo, err := ParseStageTimeouts([]string{"ProposeRetrieval=31m", "DealAccepted=3h"})
+	stageTo, err := ParseStageTimeouts([]string{"ProposeDeal=31m", "DealAccepted=3h", "default=1h"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(stageTo) != 2 {
-		t.Fatal("expected 2 retrieval timeouts")
+	if len(stageTo) != 3 {
+		t.Fatal("expected 3 retrieval timeouts")
 	}
-	to, ok := stageTo["proposeretrieval"]
+	to, ok := stageTo["proposedeal"]
 	if !ok {
-		t.Fatal("missing proposeretrieval timeout")
+		t.Fatal("missing proposedeal timeout")
 	}
 	if to != 31*time.Minute {
-		t.Error("wrong value for proposeretrieval timeout")
+		t.Error("wrong value for proposedeal timeout")
 	}
 
 	to, ok = stageTo["dealaccepted"]
@@ -40,10 +40,7 @@ func TestParseStageTimeouts(t *testing.T) {
 	}
 
 	stageTo, err = ParseStageTimeouts([]string{"unknown=3h"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stageTo != nil {
-		t.Fatal("should not have retrieval timeouts")
+	if err == nil {
+		t.Fatal("expected error with unusable stage timeout")
 	}
 }

--- a/tasks/stage_timeouts.go
+++ b/tasks/stage_timeouts.go
@@ -1,0 +1,93 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+)
+
+const (
+	defaultRetrievalStageTimeout     = 30 * time.Minute
+	defaultRetrievalStageTimeoutName = "defaultretrieval"
+	defaultStorageStageTimeout       = 3 * time.Hour
+	defaultStorageStageTimeoutName   = "defaultstorage"
+)
+
+// ParseStageTimeouts parses "StageName=timeout" strings into a map of stage
+// name to timeout duration.
+func ParseStageTimeouts(timeoutSpecs []string) (map[string]time.Duration, error) {
+	// Parse all stage timeout durations
+	timeouts := map[string]time.Duration{}
+	for _, spec := range timeoutSpecs {
+		parts := strings.SplitN(spec, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid stage timeout specification: %s", spec)
+		}
+		stage := strings.TrimSpace(parts[0])
+		timeout := strings.TrimSpace(parts[1])
+		d, err := time.ParseDuration(timeout)
+		if err != nil || d < time.Second {
+			return nil, fmt.Errorf("invalid value for stage %q timeout: %s", stage, timeout)
+		}
+		stage = strings.ToLower(stage)
+		if _, found := timeouts[stage]; found {
+			return nil, fmt.Errorf("multiple timeouts specified for stage %q", stage)
+		}
+		timeouts[stage] = d
+	}
+
+	timeoutCount := len(timeouts)
+
+	// Get default stage timeouts
+	retrievalTimeout, ok := timeouts[defaultRetrievalStageTimeoutName]
+	if !ok {
+		retrievalTimeout = defaultRetrievalStageTimeout
+		timeoutCount++
+	}
+	storageTimeout, ok := timeouts[defaultStorageStageTimeoutName]
+	if !ok {
+		storageTimeout = defaultStorageStageTimeout
+		timeoutCount++
+	}
+
+	stageTimeouts := make(map[string]time.Duration, timeoutCount)
+	stageTimeouts[defaultRetrievalStageTimeoutName] = retrievalTimeout
+	stageTimeouts[defaultStorageStageTimeoutName] = storageTimeout
+
+	// Get common stage timeouts
+	for stageName, _ := range CommonStages {
+		stageName = strings.ToLower(stageName)
+		if d, ok := timeouts[stageName]; ok {
+			stageTimeouts[stageName] = d
+		}
+	}
+
+	// Get retrieval stage timeouts
+	for stageName, _ := range RetrievalStages {
+		stageName = strings.ToLower(stageName)
+		if d, ok := timeouts[stageName]; ok {
+			stageTimeouts[stageName] = d
+		}
+	}
+
+	// Get storage stage timeouts
+	for _, stageName := range storagemarket.DealStates {
+		stageName = strings.ToLower(stageName)
+		if d, ok := timeouts[stageName]; ok {
+			stageTimeouts[stageName] = d
+		}
+	}
+
+	// Check for unused stage timeouts
+	if len(stageTimeouts) < timeoutCount {
+		for stageName, _ := range timeouts {
+			if _, ok = stageTimeouts[stageName]; !ok {
+				return nil, fmt.Errorf("unusable stage timeout: %q", stageName)
+			}
+		}
+	}
+
+	return stageTimeouts, nil
+}

--- a/tasks/stage_timeouts_test.go
+++ b/tasks/stage_timeouts_test.go
@@ -6,14 +6,22 @@ import (
 )
 
 func TestParseStageTimeouts(t *testing.T) {
-	stageTo, err := ParseStageTimeouts([]string{"ProposeDeal=31m", "DealAccepted=3h", "default=1h"})
+	stageTo, err := ParseStageTimeouts([]string{"ProposeDeal=31m", "DealAccepted=3h", "defaultRetrieval=1h"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(stageTo) != 3 {
-		t.Fatal("expected 3 retrieval timeouts")
+	if len(stageTo) != 4 {
+		t.Fatal("expected 4 retrieval timeouts")
 	}
-	to, ok := stageTo["proposedeal"]
+	to, ok := stageTo[defaultStorageStageTimeoutName]
+	if !ok {
+		t.Fatalf("missing %s timeout", defaultStorageStageTimeoutName)
+	}
+	if to != defaultStorageStageTimeout {
+		t.Errorf("wrong value for %s timeout", defaultStorageStageTimeoutName)
+	}
+
+	to, ok = stageTo["proposedeal"]
 	if !ok {
 		t.Fatal("missing proposedeal timeout")
 	}

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -25,7 +25,7 @@ import (
 const maxPriceDefault = 5e16
 const startOffsetDefault = 30760
 
-func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, task StorageTask, updateStage UpdateStage, log LogStatus, stageTimeouts map[string]time.Duration) error {
+func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, task StorageTask, updateStage UpdateStage, log LogStatus) error {
 	de := &storageDealExecutor{
 		dealExecutor: dealExecutor{
 			ctx:    ctx,
@@ -64,7 +64,7 @@ func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, 
 	if err != nil {
 		return err
 	}
-	return de.executeAndMonitorDeal(updateStage, stageTimeouts)
+	return de.executeAndMonitorDeal(updateStage)
 }
 
 type dealExecutor struct {

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -25,7 +25,7 @@ import (
 const maxPriceDefault = 5e16
 const startOffsetDefault = 30760
 
-func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, task StorageTask, updateStage UpdateStage, log LogStatus) error {
+func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, task StorageTask, updateStage UpdateStage, log LogStatus, stageTimeouts map[string]time.Duration) error {
 	de := &storageDealExecutor{
 		dealExecutor: dealExecutor{
 			ctx:    ctx,
@@ -64,7 +64,7 @@ func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, 
 	if err != nil {
 		return err
 	}
-	return de.executeAndMonitorDeal(updateStage)
+	return de.executeAndMonitorDeal(updateStage, stageTimeouts)
 }
 
 type dealExecutor struct {


### PR DESCRIPTION
When running the retrieval-deal or daemon command, specify deal stage timeouts using the `--stage-timeout` flag.  This flag can be specified multiple times to configure timeouts for deal stages.  For example:
```sh
./dealbot daemon --stage-timeout ProposeRetrieval=30m --stage-timeout DealAccepted=2h ...
```

The stage names are case-insensitive.  The timeout duration must be an integer with a suffix of "s", "m", or "h" to specify the time units.

This addresses issue #134 