### PR TITLE
Add ProposeDeal as common stage

### DIFF
--- a/tasks/model.go
+++ b/tasks/model.go
@@ -88,17 +88,17 @@ func asStageDetails(description, expected string) StageDetails {
 	}
 }
 
-// ConnectivityStages are stages that occur prior to initiating a deal
-var ConnectivityStages = map[string]StageDetails{
+// CommonStages are stages near the beginning of a deal shared between storage & retrieval
+var CommonStages = map[string]StageDetails{
 	"MinerOnline":  asStageDetails("Miner is online", "a few seconds"),
 	"QueryAsk":     asStageDetails("Miner responds to query ask", "a few seconds"),
 	"CheckPrice":   asStageDetails("Miner meets price criteria", ""),
 	"ClientImport": asStageDetails("Importing data into Lotus", "a few minutes"),
+	"ProposeDeal":  asStageDetails("Send proposal to miner", ""),
 }
 
 // RetrievalStages are stages that occur in a retrieval deal
 var RetrievalStages = map[string]StageDetails{
-	"ProposeRetrieval":  asStageDetails("Send retrieval to miner", ""),
 	"DealAccepted":      asStageDetails("Miner accepts deal", "a few seconds"),
 	"FirstByteReceived": asStageDetails("First byte of data received from miner", "a few seconds, or several hours when unsealing"),
 	"DealComplete":      asStageDetails("All bytes received and deal is completed", "a few seconds"),
@@ -142,7 +142,7 @@ type step struct {
 }
 
 func executeStage(stage string, updateStage UpdateStage, steps []step) error {
-	stageDetails, ok := ConnectivityStages[stage]
+	stageDetails, ok := CommonStages[stage]
 	if !ok {
 		return errors.New("unknown stage")
 	}

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -68,7 +68,7 @@ func (de *retrievalDealExecutor) queryOffer() error {
 }
 
 func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, updateStage UpdateStage) error {
-	dealStage := RetrievalStages["ProposeDeal"]
+	dealStage := CommonStages["ProposeDeal"]
 	err := updateStage("ProposeDeal", dealStage)
 	if err != nil {
 		return err

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -68,8 +68,8 @@ func (de *retrievalDealExecutor) queryOffer() error {
 }
 
 func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, updateStage UpdateStage) error {
-	dealStage := RetrievalStages["ProposeRetrieval"]
-	err := updateStage("ProposeRetrieval", dealStage)
+	dealStage := RetrievalStages["ProposeDeal"]
+	err := updateStage("ProposeDeal", dealStage)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 	}
 
 	dealStage = AddLog(dealStage, "deal sent to miner")
-	err = updateStage("ProposeRetrieval", dealStage)
+	err = updateStage("ProposeDeal", dealStage)
 	if err != nil {
 		return err
 	}

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -185,6 +185,11 @@ func (de *storageDealExecutor) importFile() (err error) {
 }
 
 func (de *storageDealExecutor) executeAndMonitorDeal(updateStage UpdateStage) error {
+	dealStage := CommonStages["ProposeDeal"]
+	err := updateStage("ProposeDeal", dealStage)
+	if err != nil {
+		return err
+	}
 
 	startOffset := de.task.StartOffset.x
 	if startOffset == 0 {

--- a/testutil/mockbot.go
+++ b/testutil/mockbot.go
@@ -53,8 +53,8 @@ func NewMockDaemon(ctx context.Context, cliCtx *cli.Context) (srv *MockDaemon) {
 
 func (md *MockDaemon) worker(n int) {
 	log.Infow("mock worker started", "worker_id", n)
-	baseFailStates := make([]string, 0, len(tasks.ConnectivityStages))
-	for state := range tasks.ConnectivityStages {
+	baseFailStates := make([]string, 0, len(tasks.CommonStages))
+	for state := range tasks.CommonStages {
 		baseFailStates = append(baseFailStates, state)
 	}
 	retrievalFailStates := make([]string, 0, len(tasks.RetrievalStages)-1+len(baseFailStates))
@@ -115,13 +115,13 @@ func (md *MockDaemon) worker(n int) {
 				stage = retrievalFailStates[rand.Intn(len(retrievalFailStates))]
 				stageDetails, ok = tasks.RetrievalStages[stage]
 				if !ok {
-					stageDetails = tasks.ConnectivityStages[stage]
+					stageDetails = tasks.CommonStages[stage]
 				}
 			} else {
 				stage = storageFailStates[rand.Intn(len(storageFailStates))]
 				stageDetails, ok = storageStageDetails[stage]
 				if !ok {
-					stageDetails = tasks.ConnectivityStages[stage]
+					stageDetails = tasks.CommonStages[stage]
 				}
 			}
 			taskDuration = md.failureAvg + time.Duration(rand.NormFloat64()*float64(md.failureDeviation))


### PR DESCRIPTION
# Goals

Early storage deal fails are being marked as at the "ClientImport" stage -- even though the fail is cause the deal proposal is rejected. Make it clear they failed while proposing a deal

# Implementation

- This change refactors the stages so "ProposeDeal" is shared between storage and retrieval, adding it to storage and replacing
"ProposeRetrieval" from the retrieval stages
- Also renames ConnectivityStages to CommonStages