### PR TITLE
Remove crash on controller error

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -228,13 +228,19 @@ func (e *Engine) runTask(ctx context.Context, task tasks.Task, runCount, worker 
 	}
 
 	// Update task final status. Do not use task context.
+	var stageDetails tasks.StageDetails
+	if task.CurrentStageDetails.Exists() {
+		stageDetails = task.CurrentStageDetails.Must()
+	} else {
+		stageDetails = tasks.BlankStage
+	}
 	_, err = e.client.UpdateTask(ctx, task.UUID.String(),
 		tasks.Type.UpdateTask.OfStage(
 			e.host,
 			finalStatus,
 			finalErrorMessage,
 			task.Stage.String(),
-			task.CurrentStageDetails.Must(),
+			stageDetails,
 			runCount,
 		))
 

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -88,6 +88,9 @@ func asStageDetails(description, expected string) StageDetails {
 	}
 }
 
+// BlankStage is a fallback stage for deals that fail early in an unknown stage
+var BlankStage = asStageDetails("Unknown stage", "")
+
 // CommonStages are stages near the beginning of a deal shared between storage & retrieval
 var CommonStages = map[string]StageDetails{
 	"MinerOnline":  asStageDetails("Miner is online", "a few seconds"),


### PR DESCRIPTION
# Goals

This fixes the other side of what's happening on the dealbot. While controller errors should be more rare after @gammazero 's transaction fix, we still shouldn't have a full dealbot crash when it happens.

# Implementation

- Sometimes an failed attempt to update via the controller could leave the task with no stage details, causing the final set-task-to-failed operation to panic trying to unbox a the CurrentStageDetails which is an optional (i.e. maybe) member. 
- This just avoids the panic by saving a blank stage details indicated a failure in an unknown stage when this happens.