### PR TITLE
Cleanup task update TODO

### DIFF
--- a/controller/state/statedb_test.go
+++ b/controller/state/statedb_test.go
@@ -104,6 +104,13 @@ func TestAssignTask(t *testing.T) {
 	task, err = state.AssignTask(ctx, tasks.Type.PopTask.Of("it's me", tasks.InProgress))
 	require.NoError(t, err)
 	require.Nil(t, task, "Shoud not be able to assign more tasks")
+
+	var uuid string
+	for uuid = range seen {
+		break
+	}
+	task, err = state.Get(ctx, uuid)
+	require.NoError(t, err)
 }
 
 func TestAssignConcurrentTask(t *testing.T) {

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -157,14 +157,14 @@ func executeStage(ctx context.Context, stage string, updateStage UpdateStage, st
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		err := step.stepExecution()
+		err = step.stepExecution()
 		if err != nil {
 			return err
 		}
 		stageDetails = AddLog(stageDetails, step.stepSuccess)
 		err = updateStage(ctx, stage, stageDetails)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 	return nil

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -172,7 +172,7 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 				stage = "DealComplete"
 				dealStage = RetrievalStages[stage]
 				dealStage = AddLog(dealStage, fmt.Sprintf("bytes received: %d", event.BytesReceived))
-				err := updateStage(ctx, stage, dealStage)
+				err = updateStage(ctx, stage, dealStage)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Get updated task explicitly instead of updating it via closure in function passed to other functions.  While this incurrs an additional database query, it is easier to reason about how the task is updated.