### PR TITLE
Fix Netdiag function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/lotus v1.9.0
 	github.com/golang-migrate/migrate/v4 v4.14.2-0.20210511063805-2e7358e012a6
+	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -736,12 +736,6 @@ github.com/ipfs/iptb-plugins v0.2.1/go.mod h1:QXMbtIWZ+jRsW8a4h13qAKU7jcM7qaittO
 github.com/ipld/go-car v0.1.1-0.20200923150018-8cdef32e2da4/go.mod h1:xrMEcuSq+D1vEwl+YAXsg/JfA98XGpXDwnkIL4Aimqw=
 github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d h1:iphSzTuPqyDgH7WUVZsdqUnQNzYgIblsVr1zhVNA33U=
 github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d/go.mod h1:2Gys8L8MJ6zkh1gktTSXreY63t4UbyvNp5JaudTyxHQ=
-github.com/ipld/go-ipld-graphql v0.0.0-20210425153336-bd6fb64874b6 h1:sL8KmNP+r/RyIXftsi8n4Z7wf7i54zF5p9r//zY0z6I=
-github.com/ipld/go-ipld-graphql v0.0.0-20210425153336-bd6fb64874b6/go.mod h1:mOMXf1WKBUilb6y+zerpQrDrS/mEzFmkauXfR2Tz55o=
-github.com/ipld/go-ipld-graphql v0.0.0-20210608175138-5ce6ea648d27 h1:j5hfmica0XHsiUWCvWNrMTeibF89Gduzy+ssICPM4Mg=
-github.com/ipld/go-ipld-graphql v0.0.0-20210608175138-5ce6ea648d27/go.mod h1:mOMXf1WKBUilb6y+zerpQrDrS/mEzFmkauXfR2Tz55o=
-github.com/ipld/go-ipld-graphql v0.0.0-20210608181402-402a472355ba h1:uf699sFhy7rwHX+vvcS5jS9QGbHd5jviD8eLGsCf2go=
-github.com/ipld/go-ipld-graphql v0.0.0-20210608181402-402a472355ba/go.mod h1:mOMXf1WKBUilb6y+zerpQrDrS/mEzFmkauXfR2Tz55o=
 github.com/ipld/go-ipld-graphql v0.0.0-20210608181858-5e7994523c5a h1:SHbnaSlBCr/HV1xESbE136iE+eqAPOW+B6NNKul7eBI=
 github.com/ipld/go-ipld-graphql v0.0.0-20210608181858-5e7994523c5a/go.mod h1:mOMXf1WKBUilb6y+zerpQrDrS/mEzFmkauXfR2Tz55o=
 github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e/go.mod h1:uVIwe/u0H4VdKv3kaN1ck7uCb6yD9cFLS9/ELyXbsw8=

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -6,16 +6,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/config"
 	"github.com/multiformats/go-multiaddr"
 	"golang.org/x/net/context"
 )
 
-func TryAcquireLatency(ctx context.Context, ai peer.AddrInfo) (multiaddr.Multiaddr, int64, error) {
+func TryAcquireLatency(ctx context.Context, ai peer.AddrInfo, makeHost func(ctx context.Context, opts ...config.Option) (host.Host, error)) (multiaddr.Multiaddr, int64, error) {
 	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	h, err := libp2p.New(cctx)
+	h, err := makeHost(cctx)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -355,18 +355,18 @@ func parseFinalLogs(t Task) *logExtraction {
 				le.timeLastByte.v = &_Int{entryTime.Sub(start).Milliseconds()}
 			}
 
-			if !le.minerVersion.Exists() && strings.Contains(entry, "NetAgentVersion:") {
+			if !le.minerVersion.Exists() && strings.Contains(entry, "NetAgentVersion: ") {
 				le.minerVersion.m = schema.Maybe_Value
-				le.minerVersion.v = &_String{strings.TrimPrefix(entry, "NetAgentVersion:")}
+				le.minerVersion.v = &_String{strings.TrimPrefix(entry, "NetAgentVersion: ")}
 			}
-			if !le.clientVersion.Exists() && strings.Contains(entry, "ClientVersion:") {
+			if !le.clientVersion.Exists() && strings.Contains(entry, "ClientVersion: ") {
 				le.clientVersion.m = schema.Maybe_Value
-				le.clientVersion.v = &_String{strings.TrimPrefix(entry, "ClientVersion:")}
+				le.clientVersion.v = &_String{strings.TrimPrefix(entry, "ClientVersion: ")}
 			}
-			if le.minerAddr == "" && strings.Contains(entry, "RemotePeerAddr:") {
-				le.minerAddr = strings.TrimPrefix(entry, "RemotePeerAddr:")
+			if le.minerAddr == "" && strings.Contains(entry, "RemotePeerAddr: ") {
+				le.minerAddr = strings.TrimPrefix(entry, "RemotePeerAddr: ")
 			}
-			if !le.minerLatency.Exists() && strings.Contains(entry, "RemotePeerLatency:") {
+			if !le.minerLatency.Exists() && strings.Contains(entry, "RemotePeerLatency: ") {
 				le.minerLatency.m = schema.Maybe_Value
 				val, err := strconv.Atoi(strings.TrimPrefix(entry, "RemotePeerLatency: "))
 				if err == nil {

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -13,16 +13,18 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p"
 )
 
 func MakeRetrievalDeal(ctx context.Context, config NodeConfig, node api.FullNode, task RetrievalTask, updateStage UpdateStage, log LogStatus, stageTimeouts map[string]time.Duration) error {
 	de := &retrievalDealExecutor{
 		dealExecutor: dealExecutor{
-			ctx:    ctx,
-			config: config,
-			node:   node,
-			miner:  task.Miner.x,
-			log:    log,
+			ctx:      ctx,
+			config:   config,
+			node:     node,
+			miner:    task.Miner.x,
+			log:      log,
+			makeHost: libp2p.New,
 		},
 		task: task,
 	}
@@ -223,7 +225,7 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 
 }
 
-func (rp *_RetrievalTask__Prototype) Of(minerParam string, payloadCid string, carExport bool, tag string) RetrievalTask {
+func (rp _RetrievalTask__Prototype) Of(minerParam string, payloadCid string, carExport bool, tag string) RetrievalTask {
 	rt := _RetrievalTask{
 		Miner:      _String{minerParam},
 		PayloadCID: _String{payloadCid},

--- a/tasks/storage_deal_test.go
+++ b/tasks/storage_deal_test.go
@@ -1,0 +1,75 @@
+package tasks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/config"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetDiag(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mn := mocknet.New(ctx)
+	other, err := mn.GenPeer()
+	require.NoError(t, err)
+	node := mocks.NewMockFullNode(ctrl)
+	node.EXPECT().NetAgentVersion(gomock.Eq(ctx), gomock.Eq(other.ID())).Return("1.12.0", nil)
+	node.EXPECT().Version(gomock.Eq(ctx)).Return(api.APIVersion{
+		Version: "1.11.0",
+	}, nil)
+	de := &dealExecutor{
+		ctx: ctx,
+		pi: peer.AddrInfo{
+			ID:    other.ID(),
+			Addrs: other.Addrs(),
+		},
+		node: node,
+		makeHost: func(ctx context.Context, _ ...config.Option) (host.Host, error) {
+			h, err := mn.GenPeer()
+			if err == nil {
+				mn.LinkAll()
+			}
+			return h, err
+		},
+		log: func(msg string, keysAndValues ...interface{}) {},
+	}
+	var finalStageDetails StageDetails
+	executeStage(ctx, "MinerOnline", func(ctx context.Context, stage string, stageDetails StageDetails) error {
+		finalStageDetails = stageDetails
+		return nil
+	}, []step{
+		{
+			stepExecution: de.netDiag,
+			stepSuccess:   "Got Miner Version",
+		},
+	})
+	minerVersion := assertHasLogWithPrefix(t, finalStageDetails.FieldLogs(), "NetAgentVersion: ")
+	require.Equal(t, "1.12.0", minerVersion)
+	clientVersion := assertHasLogWithPrefix(t, finalStageDetails.FieldLogs(), "ClientVersion: ")
+	require.Equal(t, "1.11.0", clientVersion)
+	remotePeerAddr := assertHasLogWithPrefix(t, finalStageDetails.FieldLogs(), "RemotePeerAddr: ")
+	require.Equal(t, other.Addrs()[0].String(), remotePeerAddr)
+	_ = assertHasLogWithPrefix(t, finalStageDetails.FieldLogs(), "RemotePeerLatency: ")
+}
+
+func assertHasLogWithPrefix(t *testing.T, logs List_Logs, prefix string) (postfix string) {
+	itr := logs.Iterator()
+	for !itr.Done() {
+		_, log := itr.Next()
+		if strings.Contains(log.FieldLog().String(), prefix) {
+			return strings.TrimPrefix(log.FieldLog().String(), prefix)
+		}
+	}
+	t.Fatalf("expected logs to contain a string that begins with: '%s'", prefix)
+	return ""
+}


### PR DESCRIPTION
# Goals

Fix an issue that cause MinerLatency not to show up. 

# Implementation

The miner latency was only getting recorded when there was an error.

Also, this ticket began as an effort to verify the logs generated by actually unit testing some of the code that talks to Lotus. As you can see, while not totally ideal, it's definitely possible to use the generated Lotus Mock API (now part of the Lotus codebase and always up to date) to write unit tests that "talk" to Lotus.