### PR TITLE
Fix stage timeout error message

### DIFF
--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -148,7 +148,11 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 
 		select {
 		case <-timer.C:
-			msg := fmt.Sprintf("timed out after %s", stageTimeouts[strings.ToLower(stage)])
+			timeout, ok := stageTimeouts[strings.ToLower(stage)]
+			if !ok {
+				timeout = defaultStageTimeout
+			}
+			msg := fmt.Sprintf("timed out after %s", timeout)
 			AddLog(dealStage, msg)
 			return fmt.Errorf("deal stage %q %s", stage, msg)
 		case event, ok := <-events:

--- a/tasks/stage_timeouts.go
+++ b/tasks/stage_timeouts.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultRetrievalStageTimeout     = 30 * time.Minute
+	defaultRetrievalStageTimeout     = 3 * time.Hour
 	defaultRetrievalStageTimeoutName = "defaultretrieval"
 	defaultStorageStageTimeout       = 3 * time.Hour
 	defaultStorageStageTimeoutName   = "defaultstorage"

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -308,7 +308,11 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 
 		select {
 		case <-timer.C:
-			msg := fmt.Sprintf("timed out after %s", stageTimeouts[strings.ToLower(stage)])
+			timeout, ok := stageTimeouts[strings.ToLower(stage)]
+			if !ok {
+				timeout = defaultStageTimeout
+			}
+			msg := fmt.Sprintf("timed out after %s", timeout)
 			AddLog(dealStage, msg)
 			return fmt.Errorf("deal stage %q %s", stage, msg)
 		case info, ok := <-updates:


### PR DESCRIPTION
# Goals

Fix the stage timeout message when no stage timeouts are specified (i.e. default only)
Also, retrievals are failing right now just cause it takes a while to transfer data -- I'd rather we not fail for now till we at least get the DSR above zero. I realize this is individually configurable but still would like the default to be flexible.