### PR TITLE
Skip 03_scheduled_task integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ commands:
     steps:
       - run: ./integration_tests/01_storage_retrieval_ok.sh
       - run: ./integration_tests/02_controller_daemon.sh
-      - run: ./integration_tests/03_scheduled_task.sh
   docker-login:
     steps:
       - run:

--- a/integration_tests/03_scheduled_task.sh
+++ b/integration_tests/03_scheduled_task.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# COMMENT TO ENABLE
-echo "${0}: test skipped"
-exit 0
-
 my_dir="$(dirname "$0")"
 source "$my_dir/header.sh"
 

--- a/integration_tests/03_scheduled_task.sh
+++ b/integration_tests/03_scheduled_task.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# COMMENT TO ENABLE
+echo "${0}: test skipped"
+exit 0
+
 my_dir="$(dirname "$0")"
 source "$my_dir/header.sh"
 


### PR DESCRIPTION
Skip the scheduled task integration test for now.  Other tests check that dealbot is able to make deals, so the only added value of this test is to check that a scheduled task is re-run due to having a schedule.