### PR TITLE
Add "AllBytesReceived" stage

### DIFF
--- a/tasks/model.go
+++ b/tasks/model.go
@@ -110,7 +110,8 @@ var CommonStages = map[string]func() StageDetails{
 var RetrievalStages = map[string]func() StageDetails{
 	"DealAccepted":      staticStageDetails("Miner accepts deal", "a few seconds"),
 	"FirstByteReceived": staticStageDetails("First byte of data received from miner", "a few seconds, or several hours when unsealing"),
-	"DealComplete":      staticStageDetails("All bytes received and deal is completed", "a few seconds"),
+	"AllBytesReceived":  staticStageDetails("All bytes received, deal wrapping up", "a few seconds"),
+	"DealComplete":      staticStageDetails("Deal is complete", "a few seconds"),
 }
 
 // the multi-codec and hash we use for cid links by default

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -22,6 +22,7 @@ const (
 	RetrievalStageProposeDeal       = RetrievalStage("ProposeDeal")
 	RetrievalStageDealAccepted      = RetrievalStage("DealAccepted")
 	RetrievalStageFirstByteReceived = RetrievalStage("FirstByteReceived")
+	RetrievalStageAllBytesReceived  = RetrievalStage("AllBytesReceived")
 	RetrievalStageDealComplete      = RetrievalStage("DealComplete")
 )
 
@@ -29,6 +30,7 @@ var RetrievalDealStages = []RetrievalStage{
 	RetrievalStageProposeDeal,
 	RetrievalStageDealAccepted,
 	RetrievalStageFirstByteReceived,
+	RetrievalStageAllBytesReceived,
 	RetrievalStageDealComplete,
 }
 
@@ -233,7 +235,7 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 				// steam closed, no errors, so the deal is a success
 
 				// deal is on chain, exit successfully
-				stage = RetrievalStageDealComplete
+				stage = RetrievalStageAllBytesReceived
 				dealStage = RetrievalStages[stage]()
 				dealStage = AddLog(dealStage, fmt.Sprintf("bytes received: %d", event.BytesReceived))
 				err = updateStage(ctx, stage, dealStage)
@@ -259,7 +261,10 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 				if de.task.CARExport.x {
 					return errors.New("car export not implemented")
 				}
-				return nil
+				// final stage
+				stage = RetrievalStageDealComplete
+				dealStage = RetrievalStages[stage]()
+				return updateStage(ctx, stage, dealStage)
 			}
 
 			// if the event has an error message, then something went wrong and deal failed


### PR DESCRIPTION
# Goals

Prevent retrievals that errored out near the end from showing "DealComplete"

# Implementation

Use AllBytesReceived where we used to use DealComplete, use DealComplete when the deal is really done