### PR TITLE
Only cancel in-progress retrievals

### DIFF
--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p"
@@ -125,7 +126,7 @@ func (de *retrievalDealExecutor) cancelOldDeals(ctx context.Context, dealStage S
 		return nil, err
 	}
 	for _, retrieval := range retrievals {
-		if retrieval.Provider == de.pi.ID && retrieval.PayloadCID.Equals(de.offer.Root) {
+		if retrieval.Provider == de.pi.ID && retrieval.PayloadCID.Equals(de.offer.Root) && !clientstates.IsFinalityState(retrieval.Status) {
 			err := de.node.ClientCancelRetrievalDeal(ctx, retrieval.ID)
 			if err != nil {
 				return nil, err

--- a/tasks/retrieval_deal_test.go
+++ b/tasks/retrieval_deal_test.go
@@ -78,6 +78,26 @@ func TestCancelOldDeals(t *testing.T) {
 				fmt.Sprintf("cancelled identical retrieval with ID %d", cancelID1),
 			},
 		},
+		"no cancels cause of finality state": {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
+				expect.ClientListRetrievals(gomock.Any()).Return(
+					[]api.RetrievalInfo{
+						{
+							ID:         retrievalmarket.DealID(rand.Uint64()),
+							PayloadCID: generateRandomCID(t),
+							Provider:   generateRandomPeer(),
+						},
+						{
+							ID:         cancelID1,
+							Status:     retrievalmarket.DealStatusCompleted,
+							PayloadCID: root,
+							Provider:   other,
+						},
+					}, nil,
+				)
+			},
+			expectedLogs: []string{},
+		},
 		"retrieval cancel errors": {
 			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(


### PR DESCRIPTION
# Goals

Ooops... if you previous completed an identical retrieval for a miner, you shouldn't cancel it after the fact... that will error! (and not cancelling will not prevent you from initiating a new one)

# Implementation

Use the same check go-fil-markets uses to verify deal is still in progress