### PR TITLE
Remove file on storage termination

### DIFF
--- a/integration_tests/01_storage_retrieval_ok.sh
+++ b/integration_tests/01_storage_retrieval_ok.sh
@@ -5,7 +5,7 @@ source "$my_dir/header.sh"
 
 export DEALBOT_MINER_ADDRESS=t01000
 
-dealbot storage-deal
+dealbot storage-deal 2>&1 | tee dealbot.log
 
 returnValue=$?
 if [[ $returnValue -ne 0 ]]; then
@@ -13,7 +13,7 @@ if [[ $returnValue -ne 0 ]]; then
 	exit 1
 fi
 
-CID=$(lotus client local | tail -1 | awk '{print $2}')
+CID=$(cat dealbot.log | grep datacid | sed 's/.*datacid": "//' | sed 's/"}//')
 
 dealbot retrieval-deal --cid=$CID
 

--- a/integration_tests/02_controller_daemon.sh
+++ b/integration_tests/02_controller_daemon.sh
@@ -76,7 +76,7 @@ if ! grep -q 'INFO.*controller.*storage task.*"miner": "t01000",.*"size": 1024,.
 	exit 1
 fi
 
-CID=$(lotus client local | tail -1 | awk '{print $2}')
+CID=$(cat dealbot-daemon.log | grep datacid | sed 's/.*datacid": "//' | sed 's/"}//')
 
 # Also queue a retrieval task of the data we just stored.
 curl --header "Content-Type: application/json" \


### PR DESCRIPTION
# Goals

recover hard drive space once a storage deal terminates by deleting the generated file

# Implementation

This is definitely a minimal approach, but it should get the job done -- just delete the generated file when the storage deal finishes executing, and clear the Lotus import

# For discussion

For a succesful deal, this won't delete until the deal goes to StorageDealActive, which can be a long time. Technically, we could delete it sooner. Is it important to add code to check for the state when the data transfer is open and delete it then (StorageDealCheckForAcceptance)