### PR TITLE
allow for `dealbot drain` cli that exits once a host is fully done

### DIFF
--- a/commands/drain.go
+++ b/commands/drain.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"context"
+	"time"
+
+	"github.com/filecoin-project/dealbot/controller/client"
+	"github.com/urfave/cli/v2"
+)
+
+var DrainCmd = &cli.Command{
+	Name:   "drain",
+	Usage:  "Stop a dealbot daemon",
+	Flags:  append(EndpointFlags, idFlag),
+	Action: drainCommand,
+}
+
+func drainCommand(c *cli.Context) error {
+	host_id := c.String("id")
+	controller := client.New(c)
+
+	// drain `host_id`
+	if err := controller.Drain(c.Context, host_id); err != nil {
+		return err
+	}
+
+	// poll until tasks from `host_id` are done.
+	for {
+		if isActive(c.Context, controller, host_id) {
+			time.Sleep(time.Second)
+		} else {
+			break
+		}
+	}
+
+	// complete `host_id`
+	return controller.Complete(c.Context, host_id)
+}
+
+func isActive(ctx context.Context, cli *client.Client, host string) bool {
+	tasks, err := cli.ListTasks(ctx)
+	if err != nil {
+		return false
+	}
+	for _, t := range tasks {
+		if t.FieldWorkedBy().Exists() && t.FieldWorkedBy().Must().String() == host {
+			if t.FieldStatus().Int() < 3 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -113,12 +113,14 @@ var EndpointFlags = []cli.Flag{
 	}),
 }
 
+var idFlag = altsrc.NewStringFlag(&cli.StringFlag{
+	Name:    "id",
+	Usage:   "set bot worker id",
+	EnvVars: []string{"DEALBOT_ID"},
+})
+
 var DaemonFlags = append(DealFlags, append(CommonFlags, append(EndpointFlags, []cli.Flag{
-	altsrc.NewStringFlag(&cli.StringFlag{
-		Name:    "id",
-		Usage:   "set bot worker id",
-		EnvVars: []string{"DEALBOT_ID"},
-	}),
+	idFlag,
 	altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "listen",
 		Usage:   "host:port to bind http server on",

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 			commands.ControllerCmd,
 			commands.QueueRetrievalCmd,
 			commands.QueueStorageCmd,
+			commands.DrainCmd,
 		},
 		Before: altsrc.InitInputSourceWithContext(append(appFlags, commands.AllFlags...), altsrc.NewYamlSourceFromFlagFunc("config")),
 	}


### PR DESCRIPTION
this seems to be the component that works well with something like https://blog.gruntwork.io/gracefully-shutting-down-pods-in-a-kubernetes-cluster-328aecec90d