### PR TITLE
hook for scheduling retrievals after successful stores

### DIFF
--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"bytes"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -280,8 +279,7 @@ func (c *Controller) getTaskHandler(w http.ResponseWriter, r *http.Request) {
 
 	if _, set := vars["parsed"]; set {
 		nilStore := func(_ ipld.LinkContext) (io.Writer, ipld.StoreCommitter, error) {
-			b := bytes.Buffer{}
-			return &b, func(_ ipld.Link) error { return nil }, nil
+			return io.Discard, func(_ ipld.Link) error { return nil }, nil
 		}
 		finished, err := task.Finalize(r.Context(), nilStore)
 		if err != nil {
@@ -289,10 +287,8 @@ func (c *Controller) getTaskHandler(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
 		dagjson.Encoder(finished, w)
 	} else {
-		w.WriteHeader(http.StatusOK)
 		dagjson.Encoder(task.Representation(), w)
 	}
 }

--- a/scheduler/hooks/retrieve_after_store.sh
+++ b/scheduler/hooks/retrieve_after_store.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Usage: bash retrieve_after_store.sh <UUID>
+# expected installed env binaries: mktemp, curl, jq
+# env vars used:
+# DEALBOT_CONTROLLER_ENDPOINT
+
+curl -o /tmp/dealbot.$1 $DEALBOT_CONTROLLER_ENDPOINT/tasks/$1\?parsed
+
+if [ "$(cat /tmp/dealbot.$1 | jq '.StorageTask == null')" = "true" ]; then
+  echo "task not a storage task."
+  exit 0
+fi
+
+if [ "$(cat /tmp/dealbot.$1 | jq '.TimeToLastByteMS == null')" = "true" ]; then
+  echo "task did not finish transfer."
+  exit 0
+fi
+
+MINER=$(cat /tmp/dealbot.$1 | jq .StorageTask.Miner -c)
+TAG=$(cat /tmp/dealbot.$1 | jq .StorageTask.Tag -c)
+PAYLOAD=$(cat /tmp/dealbot.$1 | jq .PayloadCID -c)
+
+echo "{\"Miner\": $MINER, \"Tag\": $TAG, \"PayloadCID\": \"$PAYLOAD\", \"CarExport\": false, \"Schedule\": \"$(date -v+5M +"%M %H * * *")\", \"ScheduleLimit\": 1}" | jq -c . > /tmp/dealbot.$1.json
+curl -X POST -d "@/tmp/dealbot.$1.json" -H "Content-Type: application/json" $DEALBOT_CONTROLLER_ENDPOINT/tasks/retrieval


### PR DESCRIPTION
* allow the `/tasks/<uuid>` endpoint to take a `?parsed` parameter to show derived fields instead of full logs
* add a bash script to filter to storage deals that have reached 'time to last byte' and then take the payload and request a retrieval from the same miner for that payload in a week.