### PR TITLE
Reset dealbot tasks when dealbot comes on line

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -171,6 +171,19 @@ func (c *Client) Drain(ctx context.Context, worker string) error {
 	return nil
 }
 
+func (c *Client) ResetWorker(ctx context.Context, worker string) error {
+	resp, err := c.request(ctx, "POST", "/reset-worker/"+worker, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ErrRequestFailed{resp.StatusCode}
+	}
+	return nil
+}
+
 func (c *Client) Complete(ctx context.Context, worker string) error {
 	resp, err := c.request(ctx, "POST", "/complete/"+worker, nil)
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -140,6 +140,7 @@ func NewWithDependencies(listener, graphqlListener net.Listener, gqlToken string
 		return nil, err
 	}
 	r.HandleFunc("/drain/{workedby}", srv.drainHandler).Methods("POST")
+	r.HandleFunc("/reset-worker/{workedby}", srv.resetWorkerHandler).Methods("POST")
 	r.HandleFunc("/complete/{workedby}", srv.completeHandler).Methods("POST")
 	r.HandleFunc("/pop-task", srv.popTaskHandler).Methods("POST")
 	r.HandleFunc("/tasks", srv.getTasksHandler).Methods("GET")

--- a/controller/state/interface.go
+++ b/controller/state/interface.go
@@ -19,6 +19,7 @@ type State interface {
 	NewRetrievalTask(ctx context.Context, retrievalTask tasks.RetrievalTask) (tasks.Task, error)
 	DrainWorker(ctx context.Context, worker string) error
 	PublishRecordsFrom(ctx context.Context, worker string) error
+	ResetWorkerTasks(ctx context.Context, worker string) error
 	Store(ctx context.Context) Store
 }
 

--- a/controller/state/statedb.go
+++ b/controller/state/statedb.go
@@ -780,3 +780,63 @@ func (s *stateDB) DrainWorker(ctx context.Context, worker string) error {
 	}
 	return nil
 }
+
+// ResetWorkerTasks finds all in progress tasks for a worker and resets them to as if they had never been run
+func (s *stateDB) ResetWorkerTasks(ctx context.Context, worker string) error {
+	var resetTasks []tasks.Task
+	err := s.transact(ctx, func(tx *sql.Tx) error {
+		inProgressWorkerTasks, err := tx.QueryContext(ctx, workerTasksByStatusSQL, worker, tasks.InProgress.Int())
+		if err != nil {
+			return err
+		}
+
+		for inProgressWorkerTasks.Next() {
+			var uuid, serialized string
+			err := inProgressWorkerTasks.Scan(&uuid, &serialized)
+			if err != nil {
+				return err
+			}
+
+			tp := tasks.Type.Task.NewBuilder()
+			if err = dagjson.Decoder(tp, bytes.NewBufferString(serialized)); err != nil {
+				return err
+			}
+			task := tp.Build().(tasks.Task)
+
+			updatedTask := task.Reset()
+
+			lnk, data, err := serializeToJSON(ctx, updatedTask.Representation())
+			if err != nil {
+				return err
+			}
+
+			// save the update back to DB
+			_, err = tx.ExecContext(ctx, unassignTaskSQL, uuid, data, lnk.String())
+			if err != nil {
+				return err
+			}
+
+			// reset the task in the task status ledger
+			_, err = tx.ExecContext(ctx, upsertTaskStatusSQL, uuid, updatedTask.Status.Int(), updatedTask.Stage.String(), 0, time.Now())
+			if err != nil {
+				return err
+			}
+			resetTasks = append(resetTasks, updatedTask)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if s.recorder != nil && len(resetTasks) > 0 {
+		for _, resetTask := range resetTasks {
+			if err = s.recorder.ObserveTask(resetTask); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/controller/state/statedb_dml.go
+++ b/controller/state/statedb_dml.go
@@ -97,4 +97,15 @@ const (
 	queryHeadSQL = `
 		SELECT cid FROM record_updates WHERE status = $1 AND worked_by = $2
 	`
+
+	workerTasksByStatusSQL = `
+	SELECT tasks.uuid, tasks.data FROM tasks
+	INNER JOIN task_status_ledger ON tasks.uuid=task_status_ledger.uuid
+	WHERE tasks.worked_by = $1 AND task_status_ledger.status = $2
+`
+
+	unassignTaskSQL = `
+		UPDATE tasks SET data = $2, worked_by = NULL, cid = $3
+		WHERE uuid = $1
+	`
 )

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -103,6 +103,27 @@ func (c *Controller) drainHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("\"OK\""))
 }
 
+func (c *Controller) resetWorkerHandler(w http.ResponseWriter, r *http.Request) {
+	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
+
+	logger.Debugw("handle request", "command", "resetWorker")
+	defer logger.Debugw("request handled", "command", "resetWorker")
+
+	enableCors(&w, r)
+	vars := mux.Vars(r)
+	workedBy := vars["workedby"]
+
+	err := c.db.ResetWorkerTasks(r.Context(), workedBy)
+	if err != nil {
+		log.Errorw("reset worker DB error", "err", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("\"OK\""))
+}
+
 func (c *Controller) completeHandler(w http.ResponseWriter, r *http.Request) {
 	logger := log.With("req_id", r.Header.Get("X-Request-ID"))
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -71,6 +71,15 @@ func New(ctx context.Context, cliCtx *cli.Context) (*Engine, error) {
 
 	log.Infof("remote version: %s", v.Version)
 
+	// before we do anything, reset all this workers tasks
+	err = client.ResetWorker(cliCtx.Context, host_id)
+	if err != nil {
+		// for now, just log an error if this happens... seems like there are scenarios
+		// where we want to get the dealbot up and running even though reset worker failed for
+		// whatever eason
+		log.Errorf("error resetting tasks for worker: %s", err)
+	}
+
 	e := &Engine{
 		client:        client,
 		nodeConfig:    nodeConfig,

--- a/tasks/model.go
+++ b/tasks/model.go
@@ -238,6 +238,20 @@ func (tp *_Task__Prototype) New(r RetrievalTask, s StorageTask) Task {
 	return &t
 }
 
+func (t *_Task) Reset() Task {
+	newTask := _Task{
+		UUID:                _String{t.UUID.x},
+		Status:              *Available,
+		WorkedBy:            _String__Maybe{m: schema.Maybe_Value, v: &_String{""}},
+		Stage:               _String{""},
+		CurrentStageDetails: _StageDetails__Maybe{m: schema.Maybe_Absent},
+		StartedAt:           _Time__Maybe{m: schema.Maybe_Absent},
+		RetrievalTask:       t.RetrievalTask,
+		StorageTask:         t.StorageTask,
+	}
+	return &newTask
+}
+
 func (t *_Task) Assign(worker string, status Status) Task {
 	newTask := _Task{
 		UUID:                t.UUID,


### PR DESCRIPTION
# Goals

When a dealbot shuts down without draining (i.e. unexpected shut down / crash), reset its in progress tasks.

# Implementation

- State DB method and test to reset in progress tasks for a given dealbot to as if they've never been run
- Controller endpoint for the reset workers method
- Code in engine to call reset workers on startup