### PR TITLE
fix(tasks): dont record error stage

### DIFF
--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -340,13 +340,6 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 				continue
 			}
 
-			if len(info.DealStages.Stages) > 0 {
-				err = updateStage(ctx, storagemarket.DealStates[info.State], toStageDetails(info.DealStages.Stages[len(info.DealStages.Stages)-1]))
-
-				if err != nil {
-					return err
-				}
-			}
 			if info.State != lastState {
 				de.log("Deal status",
 					"cid", info.ProposalCid,
@@ -370,10 +363,18 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 
 				logStages(info, de.log)
 				return fmt.Errorf("storage deal failed: %s", info.Message)
+			}
+
+			if len(info.DealStages.Stages) > 0 {
+				err = updateStage(ctx, storagemarket.DealStates[info.State], toStageDetails(info.DealStages.Stages[len(info.DealStages.Stages)-1]))
+
+				if err != nil {
+					return err
+				}
+			}
 
 			// deal is on chain, exit successfully
-			case storagemarket.StorageDealActive:
-
+			if info.State == storagemarket.StorageDealActive {
 				logStages(info, de.log)
 				return nil
 			}


### PR DESCRIPTION
# Goals

The stage needs to end up the final stage we're were at when an error occurred -- it shouldn't record the error state itself as a stage. 

# Implementation

For storage tasks, fix an error where the final failing stage was recorded as "StorageDealFailing"
-- the stage should be the last state the deal got to when it was running  -- basically, moves the update stage call below the return when there is an error -- the error message will still be recorded as "ErrorMessage" in the task handler.