### PR TITLE
Dont use "message" field in logs

### DIFF
--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -345,7 +345,7 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 					"cid", info.ProposalCid,
 					"piece", info.PieceCID,
 					"state", storagemarket.DealStates[info.State],
-					"message", info.Message,
+					"deal_message", info.Message,
 					"provider", info.Provider,
 				)
 				lastState = info.State
@@ -449,7 +449,7 @@ func logStages(info api.DealInfo, log LogStatus) {
 			"duration", info.Duration,
 			"deal_id", info.DealID,
 			"piece_cid", info.PieceCID,
-			"message", info.Message,
+			"deal_message", info.Message,
 			"provider", info.Provider,
 			"price", info.PricePerEpoch,
 			"verfied", info.Verified,


### PR DESCRIPTION
# Goals

It seems go-log uses the message field to in logz to hold the entire json dump of a log, and when we use message ourselves in logs, it overwrites what goes there.

# Implementation

Use deal_message instead of message in logs so as not to override the overall json dump on logz.io