### PR TITLE
parse deal message

### DIFF
--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -477,7 +477,7 @@ func messageParser(message string) []interface{} {
 	}
 	var ret []interface{}
 	for k, v := range m {
-		ret = append(ret, k, v)
+		ret = append(ret, "deal_"+k, v)
 	}
 	return ret
 }


### PR DESCRIPTION
This is not tested!

The intention of this PR is to parse the deal status Message, which is a json-encoded string and include those keys in our structured output. The intention is that these keys would be indexed in elasticsearch for easy search.

Rather than this:
```
{
  "cid": "cid123",
  ...
  "message": "{ \"key\": 37, \"key2\": 38 }"
}
```
We would instead output this:

```
{
  "cid": "cid123",
  ...
  "deal_key": 37,
  "deal_key2": 38
}
```
