### PR TITLE
Fix SQL where on tag assign

### DIFF
--- a/controller/state/statedb_dml.go
+++ b/controller/state/statedb_dml.go
@@ -53,7 +53,7 @@ const (
 	oldestAvailableTaskWithTagsSQL = `
 		SELECT uuid, data FROM tasks
 		WHERE worked_by IS NULL
-		AND tag is NULL OR tag = ANY($1)
+		AND (tag is NULL OR tag = ANY($1))
 		ORDER BY created
 		LIMIT 1
 	`
@@ -61,7 +61,7 @@ const (
 	oldestAvailableTaskWithTagsSQLsqlite = `
 		SELECT uuid, data FROM tasks
 		WHERE worked_by IS NULL
-		AND tag is NULL OR tag IN (%s)
+		AND (tag is NULL OR tag IN (%s))
 		ORDER BY created
 		LIMIT 1
 	`


### PR DESCRIPTION
# Feat

Ouch. What a difference a missing paraenthesis makes -- here the SQL keeps trying to assign the same task when a tag is present, because we have an OR that is supposed to be part of a single AND condition.

# Implementation

- Add parenthesis so that all tagged tasks are not considered "unassigned"
- Write a test to prove the fix