### PR TITLE
Correct storage price calculation

### DIFF
--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -271,7 +271,7 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 	de.log("imported deal file, got data cid", "datacid", de.importRes.Root)
 
 	// price is in fil/gib/epoch so total EpochPrice is price * deal size / 1GB
-	gib := types.NewInt(1 << 30)
+	gib := big.NewInt(1 << 30)
 	dealSize, err := de.node.ClientDealSize(ctx, de.importRes.Root)
 	if err != nil {
 		return err

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -270,6 +270,14 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 
 	de.log("imported deal file, got data cid", "datacid", de.importRes.Root)
 
+	// price is in fil/gib/epoch so total EpochPrice is price * deal size / 1GB
+	gib := types.NewInt(1 << 30)
+	dealSize, err := de.node.ClientDealSize(ctx, de.importRes.Root)
+	if err != nil {
+		return err
+	}
+	epochPrice := big.Div(big.Mul(de.price, big.NewInt(int64(dealSize.PieceSize))), gib)
+
 	// Prepare parameters for deal
 	params := &api.StartDealParams{
 		Data: &storagemarket.DataRef{
@@ -278,7 +286,7 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 		},
 		Wallet:            de.config.WalletAddress,
 		Miner:             de.minerAddress,
-		EpochPrice:        de.price,
+		EpochPrice:        epochPrice,
 		MinBlocksDuration: 2880 * 180,
 		DealStartEpoch:    de.tipSet.Height() + abi.ChainEpoch(startOffset),
 		FastRetrieval:     de.task.FastRetrieval.x,

--- a/tasks/storage_deal_test.go
+++ b/tasks/storage_deal_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/mocks"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -60,6 +65,59 @@ func TestNetDiag(t *testing.T) {
 	remotePeerAddr := assertHasLogWithPrefix(t, finalStageDetails.FieldLogs(), "RemotePeerAddr: ")
 	require.Equal(t, other.Addrs()[0].String(), remotePeerAddr)
 	_ = assertHasLogWithPrefix(t, finalStageDetails.FieldLogs(), "RemotePeerLatency: ")
+}
+
+func TestExecuteDeal(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	node := mocks.NewMockFullNode(ctrl)
+	root := generateRandomCID(t)
+	proposalCid := generateRandomCID(t)
+	basePrice := abi.NewTokenAmount(1000000000000)
+	dealInfo := make(chan api.DealInfo, 1)
+	dealInfo <- api.DealInfo{
+		ProposalCid: proposalCid,
+		State:       storagemarket.StorageDealActive,
+		DealStages:  &storagemarket.DealStages{},
+	}
+
+	de := &storageDealExecutor{
+		dealExecutor: dealExecutor{
+			ctx:    ctx,
+			node:   node,
+			log:    func(msg string, keysAndValues ...interface{}) {},
+			tipSet: &types.TipSet{},
+		},
+		task: Type.StorageTask.Of("f1000", 1000000000000, 21474836480, 6152, true, true, "verified"),
+		importRes: &api.ImportRes{
+			Root: root,
+		},
+		price: basePrice,
+	}
+	node.EXPECT().ClientDealSize(gomock.Eq(ctx), gomock.Eq(root)).Return(api.DataSize{
+		// 32GB Deal
+		PieceSize: 1 << 35,
+	}, nil)
+
+	node.EXPECT().ClientStartDeal(gomock.Eq(ctx), gomock.Eq(&api.StartDealParams{
+		Data: &storagemarket.DataRef{
+			TransferType: storagemarket.TTGraphsync,
+			Root:         de.importRes.Root,
+		},
+		Wallet:            de.config.WalletAddress,
+		Miner:             de.minerAddress,
+		EpochPrice:        big.Mul(basePrice, big.NewInt(32)),
+		MinBlocksDuration: 2880 * 180,
+		DealStartEpoch:    de.tipSet.Height() + abi.ChainEpoch(6152),
+		FastRetrieval:     de.task.FastRetrieval.x,
+		VerifiedDeal:      de.task.Verified.x,
+	})).Return(&proposalCid, nil)
+
+	node.EXPECT().ClientGetDealUpdates(gomock.Eq(ctx)).Return(dealInfo, nil)
+
+	err := de.executeAndMonitorDeal(ctx, func(ctx context.Context, stage string, stageDetails StageDetails) error { return nil }, map[string]time.Duration{})
+	require.NoError(t, err)
 }
 
 func assertHasLogWithPrefix(t *testing.T, logs List_Logs, prefix string) (postfix string) {


### PR DESCRIPTION
# Goals

We're rejecting deals cause:
- Miner ask in FIL/GB/Epoch
- Actual price in deal is in FIL/Epoch for total piece size

We need to adjust price based on deal size

# Implementation

This is cribbed from the interactive deal flow for Lotus.

- Use API to get full piece size
- Multiply minerAsk * deal piece size / 1GB = StoragePricePerEpoch
- Add a test