### PR TITLE
flag /secret passing so that ajax can be credentialed

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -163,6 +163,11 @@ var DaemonFlags = append(DealFlags, append(CommonFlags, append(EndpointFlags, []
 		Usage:   "file / stream to write out a json line for each task as it updates",
 		EnvVars: []string{"DEALBOT_DATAPOINT_LOG"},
 	}),
+	altsrc.NewStringFlag(&cli.StringFlag{
+		Name:    "basicauth",
+		Usage:   "the basic auth credentials needed to access the controller if in place",
+		EnvVars: []string{"DEALBOT_BASICAUTH"},
+	}),
 }...)...)...)
 
 var MockFlags = []cli.Flag{

--- a/controller/app/index.js
+++ b/controller/app/index.js
@@ -1,6 +1,11 @@
 import "./jquery-global";
 import "bootstrap-cron-picker/dist/cron-picker";
 
+let auth = "";
+window.setauth = (a) => {
+    auth = a;
+};
+
 $().ready(() => {
     $('#newSchedule').cronPicker();
 
@@ -51,6 +56,14 @@ function doSubmit(e) {
         }
     }
 
+    username = undefined;
+    password = undefined;
+    if (auth != "") {
+        let ap = auth.split(":");
+        username = ap[0];
+        password = ap[1];
+    }
+
     for (let i = 0; i < miners.length; i++) {
         let miner = miners[i];
         let url = "/tasks/storage";
@@ -86,6 +99,8 @@ function doSubmit(e) {
             type: "POST",
             url: url,
             data: data,
+            username: username,
+            password: password,
             success: done,
         });
     }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -46,6 +46,7 @@ type Controller struct {
 	gl              net.Listener
 	doneCh          chan struct{}
 	db              state.State
+	basicauth       string
 	metricsRecorder metrics.MetricsRecorder
 }
 
@@ -124,6 +125,7 @@ var static embed.FS
 func NewWithDependencies(ctx *cli.Context, listener, graphqlListener net.Listener, recorder metrics.MetricsRecorder, backend state.State) (*Controller, error) {
 	srv := new(Controller)
 	srv.db = backend
+	srv.basicauth = ctx.String("basicauth")
 
 	r := mux.NewRouter().StrictSlash(true)
 
@@ -151,6 +153,7 @@ func NewWithDependencies(ctx *cli.Context, listener, graphqlListener net.Listene
 	r.HandleFunc("/tasks/{uuid}", srv.getTaskHandler).Methods("GET")
 	r.HandleFunc("/car", srv.carHandler).Methods("GET")
 	r.HandleFunc("/health", srv.healthHandler).Methods("GET")
+	r.HandleFunc("/cred.js", srv.authHandler).Methods("GET")
 	r.Methods("OPTIONS").HandlerFunc(srv.sendCORSHeaders)
 	metricsHandler := recorder.Handler()
 	if metricsHandler != nil {

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -129,5 +129,6 @@
         </div>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
         <script src='script.js'></script>
+        <script src='cred.js'></script>
     </body>
 </html>

--- a/controller/tasks.go
+++ b/controller/tasks.go
@@ -364,3 +364,8 @@ func (c *Controller) sendCORSHeaders(w http.ResponseWriter, r *http.Request) {
 	enableCors(&w, r)
 	w.WriteHeader(http.StatusOK)
 }
+
+func (c *Controller) authHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
+	w.Write([]byte(fmt.Sprintf("setauth(\"%s\");", c.basicauth)))
+}


### PR DESCRIPTION
env var specifying "username:password" will turn into a jsonp fetch (which will get implicit creds) and will be kept in local browser state so that subsequent ajax can also be credentialed