### PR TITLE
Return error if update channel shuts down

### DIFF
--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -348,7 +348,7 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 			return fmt.Errorf("deal stage %q %s", stage, msg)
 		case info, ok := <-updates:
 			if !ok {
-				return nil
+				return fmt.Errorf("Client error: Update channel closed before deal is active")
 			}
 
 			if !proposalCid.Equals(info.ProposalCid) {


### PR DESCRIPTION
# Goals

Don't record successes for deals which end because the updates channel from lotus unexpectedly shuts down

# Implementation

Return a client error when the updates channel closes. We can filter this out of the dashboard.