### PR TITLE
increment dealbot chart version for daemon driver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ workflows:
       - deploy-lotusinfra:
           name: deploy-nerpanet-controller
           chart: filecoin/dealbot
-          chart_version: 0.0.8
+          chart_version: 0.0.9
           circle_context: sentinel-staging-deploy
           kubernetes_cluster: mainnet-us-east-2-dev-eks
           aws_region: us-east-2
@@ -161,7 +161,7 @@ workflows:
       - deploy-lotusinfra:
           name: deploy-mainnet-controller
           chart: filecoin/dealbot
-          chart_version: 0.0.8
+          chart_version: 0.0.9
           circle_context: filecoin-mainnet-aws
           kubernetes_cluster: mainnet-us-east-1-eks
           aws_region: us-east-1


### PR DESCRIPTION
this chart version includes the env var DEALBOT_DAEMON_DRIVER needed to properly deploy new dealbot daemons using the new self serve model in kubernetes

see https://github.com/filecoin-project/helm-charts/pull/92