### PR TITLE
Fix panic when iterating nodes

### DIFF
--- a/controller/spawn/kubernetes.go
+++ b/controller/spawn/kubernetes.go
@@ -88,7 +88,9 @@ func (s *KubernetesSpawner) List(regionid string) (daemons []*Daemon, err error)
 	}
 	for _, r := range releases {
 		d := daemonFromRelease(r, regionid)
-		daemons = append(daemons, d)
+		if d != nil {
+			daemons = append(daemons, d)
+		}
 	}
 	return daemons, nil
 }
@@ -165,6 +167,9 @@ func NewKubernetes() *KubernetesSpawner {
 // the Daemon struct. If they don't exist, the Daemon will
 // have zero-values
 func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
+	if r.Config["application"] == nil {
+		return nil
+	}
 	container := r.Config["application"].(map[string]interface{})["container"]
 	kcontainer := new(corev1.Container)
 	buf, _ := yaml.Marshal(container)


### PR DESCRIPTION
# Goals

After getting my whole kubeconfig setup, I found I still couldn't properly iterate the daemons, and it turned out to be due to the fact that several of the releases iterated were not daemon nodes, and therefor caused a panic in this function

# Implementation

in order to correctly iterate daemon nodes, we need to filter out those that are not the daemon
(i.e. don't have the correct setup for a key)

for now, just skip these elements.

I can config I can now CURL /regions/mainnet-us-east-1 and get a list of daemons and wallets (woohoo!)