### PR TITLE
Dont rely on local helm chart

### DIFF
--- a/controller/spawn/kubernetes.go
+++ b/controller/spawn/kubernetes.go
@@ -30,7 +30,8 @@ func (s *KubernetesSpawner) Spawn(d *Daemon) error {
 		return err
 	}
 	client := action.NewInstall(actionConfig)
-	chartPath, err := client.ChartPathOptions.LocateChart("filecoin/lotus-bundle",
+	client.ChartPathOptions.RepoURL = "https://filecoin-project.github.io/helm-charts"
+	chartPath, err := client.ChartPathOptions.LocateChart("lotus-bundle",
 		helmcli.New())
 	if err != nil {
 		log.Infow("could not determine chart path", "err", err)


### PR DESCRIPTION
# Goals

I found that initially I was unable to find the helm chart to spawn a demon on my local machine. It turns out helm needs a remote repo to pull charts from, and existing code was depending on that remote repo already being added to the local machines helm config.  Instead of using the local config, actually manually point at the remote repo so we don't have to worry about trying to setup helm and add a config to the docker container

# Implementation

set repo url and then change name to match. I can config that I am able to spawn a daemon from my local machine with these configs