### PR TITLE
Fix reset worker sql

### DIFF
--- a/controller/state/statedb_dml.go
+++ b/controller/state/statedb_dml.go
@@ -105,9 +105,13 @@ const (
 	`
 
 	workerTasksByStatusSQL = `
-	SELECT tasks.data FROM tasks
-	INNER JOIN task_status_ledger ON tasks.uuid=task_status_ledger.uuid
-	WHERE tasks.worked_by = $1 AND task_status_ledger.status = $2
+	SELECT unique_statuses.data FROM (
+		SELECT DISTINCT ON(tasks.uuid) tasks.data, task_status_ledger.status 
+		  FROM tasks
+			INNER JOIN task_status_ledger ON tasks.uuid=task_status_ledger.uuid
+			WHERE tasks.worked_by = $1 
+			ORDER BY tasks.uuid, task_status_ledger.ts DESC 
+	 ) unique_statuses WHERE unique_statuses.status = $2
 `
 
 	unassignScheduledTaskSQL = `

--- a/controller/state/statedb_test.go
+++ b/controller/state/statedb_test.go
@@ -501,10 +501,14 @@ func TestResetWorkerTasks(t *testing.T) {
 		req = tasks.Type.PopTask.Of(worker, tasks.Failed)
 		failedTask, err := state.AssignTask(ctx, req)
 		require.NoError(t, err)
+		failedTask, err = state.Update(ctx, failedTask.GetUUID(), tasks.Type.UpdateTask.Of(inProgressTask2.WorkedBy.Must().String(), tasks.Failed, 1))
+		require.NoError(t, err)
 
-		// pop a task and set it successful
-		req = tasks.Type.PopTask.Of(worker, tasks.Successful)
+		// pop a task to in progress, then set it successful
+		req = tasks.Type.PopTask.Of(worker, tasks.InProgress)
 		successfulTask, err := state.AssignTask(ctx, req)
+		require.NoError(t, err)
+		successfulTask, err = state.Update(ctx, successfulTask.GetUUID(), tasks.Type.UpdateTask.Of(inProgressTask2.WorkedBy.Must().String(), tasks.Successful, 1))
 		require.NoError(t, err)
 
 		// pop two tasks to the other worker and leave them in progress
@@ -526,9 +530,6 @@ func TestResetWorkerTasks(t *testing.T) {
 			}
 		}
 		require.NotNil(t, unassignedTask)
-
-		history, _ := state.TaskHistory(ctx, inProgressTask1.GetUUID())
-		fmt.Println(history)
 
 		state.ResetWorkerTasks(ctx, worker)
 


### PR DESCRIPTION
# Goals

It turns out there was a significant error in our reset worker SQL -- it was identifying even successful
and failed tasks as in progress and then resetting them. 

The challenge is determining via SQL the actual tasks that are assigned to a worker and currently in progress -- because we maintain the entire status history. The tasks we want to reset are not those with at least one entry in the task_status_ledger marked in progress, but the MOST RECENT task_status_ledger marked in progress. Actually implementing this in SQL is quite difficult -- thank goodness for PostgreSQL's SELECT DISTINCT ON (a fairly non standard SQL addition).

# Implementation

- Write a test that demonstrates the issue (will fail with current SQL reseting successful and failed tasks)
- Rewrite the SQL to actually get the test to pass.