### PR TITLE
use default storage values from latest lotus-bundle chart

### DIFF
--- a/controller/spawn/base.yaml
+++ b/controller/spawn/base.yaml
@@ -65,9 +65,6 @@ application:
         name: dealbot
   ingress:
     enabled: false
-  storage: # storage volume shared between application and lotus node
-    size: 1000Gi
-    mount: /shared
 
 # Wallets are added to the wallet secret.
 # if you don't want to specify wallets in values.yaml,


### PR DESCRIPTION
this storage stanza is incompatible with latest lotus-bundle helm chart
the latest chart uses a emptyDir volume that can hopefully be shared between dealbot daemon and lotus