### PR TITLE
Fix JS compile in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 FROM golang:alpine AS builder
 RUN apk update
 RUN apk upgrade
-RUN apk add --update gcc>=9.3.0 g++>=9.3.0 alpine-sdk linux-headers
+RUN apk add --update gcc>=9.3.0 g++>=9.3.0 alpine-sdk linux-headers binutils-gold
 
 WORKDIR /go/src/app/
 

--- a/controller/app/package-lock.json
+++ b/controller/app/package-lock.json
@@ -9,11 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@babel/runtime": "^7.14.6",
         "@glif/filecoin-number": "^1.1.0",
         "bootstrap-cron-picker": "^1.0.0",
         "bootstrap-table": "^1.18.3",
         "jquery": "^3.6.0",
         "pretty-bytes": "^5.6.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@glif/filecoin-number": {
@@ -112,9 +125,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     }
   },
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@glif/filecoin-number": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@glif/filecoin-number/-/filecoin-number-1.1.0.tgz",
@@ -193,6 +221,12 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
       "dev": true
     }
   }

--- a/controller/app/package.json
+++ b/controller/app/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/filecoin-project/dealbot#readme",
   "devDependencies": {
+    "@babel/runtime": "^7.14.6",
     "@glif/filecoin-number": "^1.1.0",
     "bootstrap-cron-picker": "^1.0.0",
     "bootstrap-table": "^1.18.3",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -193,7 +193,7 @@ func NewWithDependencies(ctx *cli.Context, listener, graphqlListener net.Listene
 
 	if ctx.IsSet("devAssetDir") {
 		scriptResolver := func(w http.ResponseWriter, r *http.Request) {
-			data := webutil.Compile(path.Join(ctx.String("devAssetDir"), "app"), false)
+			data, _ := webutil.Compile(path.Join(ctx.String("devAssetDir"), "app"), false)
 			w.Header().Set("Content-Type", "application/json")
 			io.WriteString(w, data)
 		}

--- a/controller/webutil/build.go
+++ b/controller/webutil/build.go
@@ -1,13 +1,14 @@
 package webutil
 
 import (
+	"errors"
 	"path"
 
 	"github.com/evanw/esbuild/pkg/api"
 )
 
 // Compile executes esbuild to bundle client-side app logic
-func Compile(rootPath string, minify bool) string {
+func Compile(rootPath string, minify bool) (string, error) {
 	opts := api.BuildOptions{
 		EntryPoints: []string{path.Join(rootPath, "index.js")},
 		Outfile:     "script.js",
@@ -22,7 +23,7 @@ func Compile(rootPath string, minify bool) string {
 	}
 	res := api.Build(opts)
 	if len(res.Errors) > 0 {
-		return ""
+		return "", errors.New("failed to compile web js")
 	}
-	return string(res.OutputFiles[0].Contents)
+	return string(res.OutputFiles[0].Contents), nil
 }

--- a/controller/webutil/gen/gen.go
+++ b/controller/webutil/gen/gen.go
@@ -26,7 +26,11 @@ func main() {
 		}
 	}
 
-	data := webutil.Compile(os.Args[1], true)
+	data, err := webutil.Compile(os.Args[1], true)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	if len(os.Args) < 3 {
 		fmt.Printf("%s\n", data)
 		os.Exit(0)


### PR DESCRIPTION
# Goals

Fix the frontend.

# Implementation

- There was a missing NPM package breaking the frontend static assets compile
- I also discovered in the process the docker image still builds even under this case -- we should fail so that we fail CI when this happens!
- one minor other change in dockerfile to get it to build on my Apple M1 machine (I have no idea why this incantation works other than it fixed a missing `ld` executable)

