### PR TITLE
Fix FIL display amounts

### DIFF
--- a/controller/app/index.js
+++ b/controller/app/index.js
@@ -122,37 +122,35 @@ function gotDaemons(data) {
     const daemons = data["daemons"]
     const processedDaemons = daemons.map((daemon) => {
         let daemonData = daemon.daemon
+        daemonData.minfil = new FilecoinNumber(daemonData.minfil, 'attofil')
+        daemonData.mincap = BigInt(daemonData.mincap)
         if (daemon.funds) {
-            daemonData.balance = daemon.funds.balance
-            daemonData.datacap = daemon.funds.datacap
+            daemonData.balance = new FilecoinNumber(daemon.funds.balance, 'attofil')
+            daemonData.datacap = BigInt(daemon.funds.datacap)
         }
         return daemonData
     })
     if (firstDaemonsLoad) {
-        let filFormatter = (d) => d ? (new FilecoinNumber(d, 'attofil')).toFil() + " FIL" : "-"
-        let capFormatter = (c) => c ? prettyBytes(c) : "-"
+        let filFormatter = (d) => d ? d.toFil() + " FIL" : "-"
+        let capFormatter = (c) => c ? prettyBytes(Number(c)) : "-"
         let capStyler = (value, row) => {
             // assume no value + no data-cap = miner making unverified deals = no styling
-            if (!value && !row.mincap) {
+            if (value == 0 && row.mincap == 0) {
                 return {}
             }
-            const valNumber = value || 0
-            const minCap = row.mincap || 0
-            if (valNumber < minCap) {
+            if (value < row.mincap) {
                 return { classes: 'table-danger' }
             }
-            if (valNumber - minCap < ((1 << 30)*32)) {
+            if (value - row.mincap < ((1 << 30)*32)) {
                 return { classes: 'table-warning' }
             }
             return { classes: 'table-success' }
         }
         let filStyler = (value, row) => {
-            const minBal = row.minbal || 0
-            const valNumber = value || 0
-            if (value < row.minbal) {
+            if (value < row.minfil) {
                 return { classes: 'table-danger' }
             }
-            if (valNumber - minBal < Math.pow(10, 18)) {
+            if (value - row.minfil < 1) {
                 return { classes: 'table-warning' }
             }
             return { classes: 'table-success' }

--- a/controller/daemons.go
+++ b/controller/daemons.go
@@ -23,7 +23,7 @@ import (
 
 type Funds struct {
 	Balance big.Int `json:"balance,omitempty"`
-	DataCap int     `json:"datacap,omitempty"`
+	DataCap big.Int `json:"datacap,omitempty"`
 }
 
 type DaemonWithFunds struct {
@@ -155,7 +155,7 @@ func toDaemonWithFunds(ctx context.Context, daemon *spawn.Daemon, gateway api.Ga
 	if err == nil {
 		dataCap, err := gateway.StateVerifiedClientStatus(ctx, addr, head.Key())
 		if err == nil && dataCap != nil {
-			daemonWithFunds.Funds.DataCap = int(dataCap.Int64())
+			daemonWithFunds.Funds.DataCap = *dataCap
 		}
 	}
 	return

--- a/controller/daemons.go
+++ b/controller/daemons.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/dealbot/controller/spawn"
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/google/uuid"
 
 	"github.com/filecoin-project/lotus/api"
@@ -21,8 +22,8 @@ import (
 )
 
 type Funds struct {
-	Balance int `json:"balance,omitempty"`
-	DataCap int `json:"datacap,omitempty"`
+	Balance big.Int `json:"balance,omitempty"`
+	DataCap int     `json:"datacap,omitempty"`
 }
 
 type DaemonWithFunds struct {
@@ -147,7 +148,7 @@ func toDaemonWithFunds(ctx context.Context, daemon *spawn.Daemon, gateway api.Ga
 	}
 	balance, err := gateway.WalletBalance(ctx, addr)
 	if err == nil {
-		daemonWithFunds.Funds.Balance = int(balance.Int64())
+		daemonWithFunds.Funds.Balance = balance
 	}
 
 	head, err := gateway.ChainHead(ctx)

--- a/controller/spawn/kubernetes.go
+++ b/controller/spawn/kubernetes.go
@@ -3,7 +3,6 @@ package spawn
 import (
 	"io/ioutil"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/filecoin-project/go-state-types/big"
@@ -176,8 +175,7 @@ func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
 	kcontainer := new(corev1.Container)
 	buf, _ := yaml.Marshal(container)
 	yaml.Unmarshal(buf, kcontainer)
-	var mincap int
-	var minfil big.Int
+	var minfil, mincap big.Int
 	var tags []string
 	wallet := new(Wallet)
 	for _, env := range kcontainer.Env {
@@ -189,7 +187,7 @@ func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
 		case "DEALBOT_MIN_FIL":
 			minfil, _ = big.FromString(env.Value)
 		case "DEALBOT_MIN_CAP":
-			mincap, _ = strconv.Atoi(env.Value)
+			mincap, _ = big.FromString(env.Value)
 		}
 	}
 	return &Daemon{

--- a/controller/spawn/kubernetes.go
+++ b/controller/spawn/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/filecoin-project/go-state-types/big"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	helmcli "helm.sh/helm/v3/pkg/cli"
@@ -175,7 +176,8 @@ func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
 	kcontainer := new(corev1.Container)
 	buf, _ := yaml.Marshal(container)
 	yaml.Unmarshal(buf, kcontainer)
-	var minfil, mincap int
+	var mincap int
+	var minfil big.Int
 	var tags []string
 	wallet := new(Wallet)
 	for _, env := range kcontainer.Env {
@@ -185,7 +187,7 @@ func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
 		case "DEALBOT_WALLET_ADDRESS":
 			wallet.Address = env.Value
 		case "DEALBOT_MIN_FIL":
-			minfil, _ = strconv.Atoi(env.Value)
+			minfil, _ = big.FromString(env.Value)
 		case "DEALBOT_MIN_CAP":
 			mincap, _ = strconv.Atoi(env.Value)
 		}

--- a/controller/spawn/local.go
+++ b/controller/spawn/local.go
@@ -38,7 +38,7 @@ func (s *LocalSpawner) Spawn(d *Daemon) error {
 			"DEALBOT_WORKERS":             strconv.Itoa(d.Workers),
 			"DEALBOT_CONTROLLER_ENDPOINT": s.endpoint,
 			"DEALBOT_MIN_FIL":             d.MinFil.String(),
-			"DEALBOT_MIN_CAP":             strconv.Itoa(d.MinCap),
+			"DEALBOT_MIN_CAP":             d.MinCap.String(),
 		}),
 		Args:   []string{exe, "daemon"},
 		Stdout: os.Stdout,
@@ -126,7 +126,7 @@ func daemonFromCmd(daemoncmd exec.Cmd, daemonid string) *Daemon {
 	env := envMap(daemoncmd.Env)
 	workers, _ := strconv.Atoi(env["DEALBOT_WORKERS"])
 	minfil, _ := big.FromString(env["DEALBOT_MIN_FIL"])
-	mincap, _ := strconv.Atoi(env["DEALBOT_MIN_CAP"])
+	mincap, _ := big.FromString(env["DEALBOT_MIN_CAP"])
 	return &Daemon{
 		Id:     daemonid,
 		Region: "local",

--- a/controller/spawn/local.go
+++ b/controller/spawn/local.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/filecoin-project/go-state-types/big"
 )
 
 // Start dealbot daemons locally
@@ -35,7 +37,7 @@ func (s *LocalSpawner) Spawn(d *Daemon) error {
 			"DEALBOT_WALLET_ADDRESS":      d.Wallet.Address,
 			"DEALBOT_WORKERS":             strconv.Itoa(d.Workers),
 			"DEALBOT_CONTROLLER_ENDPOINT": s.endpoint,
-			"DEALBOT_MIN_FIL":             strconv.Itoa(d.MinFil),
+			"DEALBOT_MIN_FIL":             d.MinFil.String(),
 			"DEALBOT_MIN_CAP":             strconv.Itoa(d.MinCap),
 		}),
 		Args:   []string{exe, "daemon"},
@@ -123,7 +125,7 @@ func envStr(em map[string]string) []string {
 func daemonFromCmd(daemoncmd exec.Cmd, daemonid string) *Daemon {
 	env := envMap(daemoncmd.Env)
 	workers, _ := strconv.Atoi(env["DEALBOT_WORKERS"])
-	minfil, _ := strconv.Atoi(env["DEALBOT_MIN_FIL"])
+	minfil, _ := big.FromString(env["DEALBOT_MIN_FIL"])
 	mincap, _ := strconv.Atoi(env["DEALBOT_MIN_CAP"])
 	return &Daemon{
 		Id:     daemonid,

--- a/controller/spawn/spawner.go
+++ b/controller/spawn/spawner.go
@@ -19,7 +19,7 @@ type Daemon struct {
 	Tags       []string `json:"tags,omitempty"`
 	Workers    int      `json:"workers,omitempty"`
 	MinFil     big.Int  `json:"minfil,omitempty"`
-	MinCap     int      `json:"mincap,omitempty"`
+	MinCap     big.Int  `json:"mincap,omitempty"`
 	DockerRepo string   `json:"dockerrepo,omitempty"`
 	DockerTag  string   `json:"dockerrtag,omitempty"`
 	Wallet     *Wallet  `json:"wallet,omitempty"`

--- a/controller/spawn/spawner.go
+++ b/controller/spawn/spawner.go
@@ -3,6 +3,7 @@ package spawn
 import (
 	"errors"
 
+	"github.com/filecoin-project/go-state-types/big"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -17,7 +18,7 @@ type Daemon struct {
 	Region     string   `json:"region,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 	Workers    int      `json:"workers,omitempty"`
-	MinFil     int      `json:"minfil,omitempty"`
+	MinFil     big.Int  `json:"minfil,omitempty"`
 	MinCap     int      `json:"mincap,omitempty"`
 	DockerRepo string   `json:"dockerrepo,omitempty"`
 	DockerTag  string   `json:"dockerrtag,omitempty"`


### PR DESCRIPTION
# Goals

Datacap and FIL were handled as ints in the daemon spawner, which caused unusual behavior, as they are often > max integer values

# Implementation

Convert to BigInt in go and on frontend.