### PR TITLE
switch shared storage back to efs

### DIFF
--- a/controller/spawn/base.yaml
+++ b/controller/spawn/base.yaml
@@ -65,6 +65,12 @@ application:
         name: dealbot
   ingress:
     enabled: false
+  storage:
+    - mount: /shared
+      volume:
+        - name: shared-volume
+          persistentVolumeClaim:
+              claimName: chain-exports
 
 # Wallets are added to the wallet secret.
 # if you don't want to specify wallets in values.yaml,


### PR DESCRIPTION
shared storage must be read-writeable by all.
emptyDir volumes currently provide insufficient space for dealbot daemons which need to stage 32GB sectors