### PR TITLE
Remove all on retrieval cleanup!

### DIFF
--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -308,7 +308,7 @@ func (de *retrievalDealExecutor) executeAndMonitorDeal(ctx context.Context, upda
 				}
 				dbPath := filepath.Join(de.config.DataDir, de.task.PayloadCID.x)
 				if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
-					if err := os.Remove(dbPath); err != nil {
+					if err := os.RemoveAll(dbPath); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
# Goals

Retrievals of directories are not getting cleanup properly, as os.Remove only deletes empty directories.

# Implementation

os.RemoveAll is needed to delete non empty directories