### PR TITLE
Daemon actions

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -184,6 +184,7 @@ func NewWithDependencies(ctx *cli.Context, listener, graphqlListener net.Listene
 	r.HandleFunc("/regions/{regionid}", srv.getDaemonsHandler).Methods("GET")
 	r.HandleFunc("/regions/{regionid}", srv.newDaemonHandler).Methods("POST")
 	r.HandleFunc("/regions/{regionid}/{daemonid}", srv.getDaemonHandler).Methods("GET")
+	r.HandleFunc("/regions/{regionid}/{daemonid}", srv.deleteDaemonHandler).Methods("DELETE")
 	r.HandleFunc("/cred.js", srv.authHandler).Methods("GET")
 	r.Methods("OPTIONS").HandlerFunc(srv.sendCORSHeaders)
 	metricsHandler := recorder.Handler()

--- a/controller/spawn/kubernetes.go
+++ b/controller/spawn/kubernetes.go
@@ -74,6 +74,20 @@ func (s *KubernetesSpawner) Get(regionid string, daemonid string) (daemon *Daemo
 	return daemon, nil
 }
 
+func (s *KubernetesSpawner) Shutdown(regionid string, daemonid string) error {
+	actionConfig, err := s.actionConfig(regionid)
+	if err != nil {
+		log.Infow("could not create actionConfig during daemon Get", "err", err)
+		return err
+	}
+	client := action.NewUninstall(actionConfig)
+	_, err = client.Run(daemonid)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *KubernetesSpawner) List(regionid string) (daemons []*Daemon, err error) {
 	actionConfig, err := s.actionConfig(regionid)
 	if err != nil {

--- a/controller/spawn/local.go
+++ b/controller/spawn/local.go
@@ -76,6 +76,16 @@ func (s *LocalSpawner) Get(regionid string, daemonid string) (*Daemon, error) {
 	return daemonFromCmd(daemoncmd, daemonid), nil
 }
 
+func (s *LocalSpawner) Shutdown(regionid string, daemonid string) error {
+	s.Lock()
+	defer s.Unlock()
+	daemoncmd, ok := s.cmds[daemonid]
+	if !ok {
+		return DaemonNotFound
+	}
+	return daemoncmd.Process.Signal(os.Interrupt)
+}
+
 func (s *LocalSpawner) List(regionid string) ([]*Daemon, error) {
 	s.Lock()
 	defer s.Unlock()

--- a/controller/spawn/spawner.go
+++ b/controller/spawn/spawner.go
@@ -33,6 +33,7 @@ type Wallet struct {
 type Spawner interface {
 	Spawn(*Daemon) error
 	Get(string, string) (*Daemon, error)
+	Shutdown(string, string) error
 	List(string) ([]*Daemon, error)
 	Regions() []string
 }

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -7,7 +7,35 @@
         <link href="style.css" rel="stylesheet" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
-    <body class="container">
+    <body class="container-fluid">
+        <!-- Confirmation Modal -->
+        <div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                <h5 class="modal-title" id="confirmationModalLabel">Are you sure you want to shutdown this daemon?</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                Shutting down this daemon will immediately interrupt any running daemon tasks and terminate the Lotus instance. If you do not have the daemon's private key stored elsewhere, it will be lost.
+                </div>
+                <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No Thanks</button>
+                <button type="button" id="shutdownConfirm" class="btn btn-danger">Shutdown</button>
+                </div>
+            </div>
+            </div>
+        </div>
+        <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
+            <div id="notificationMessage" class="toast hide align-items-center text-white border-0" role="alert" aria-live="assertive" aria-atomic="true">
+                <div class="d-flex">
+                <div class="toast-body">
+                    Hello, world! This is a toast message.
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+                </div>
+            </div>
+        </div>
         <h1>Dealbot</h1>
         <div class="accordion" id="mainOptions">
             <section class="accordion-item">
@@ -122,7 +150,7 @@
                         Bots
                     </button>
                 </h2>
-                <div id="botsection" class="accordion-collapse collapse container" aria-labelledby="headingBots" data-bs-parent="#mainOptions">
+                <div id="botsection" class="accordion-collapse collapse" aria-labelledby="headingBots" data-bs-parent="#mainOptions">
                     <div class="accordion-body">
                                 Region list:
                                 <div id="regionlist" class="list-group">
@@ -179,7 +207,7 @@
                         Create Bots
                     </button>
                 </h2>
-                <div id="botcreatesection" class="accordion-collapse collapse container" aria-labelledby="headingBotCreate" data-bs-parent="#mainOptions">
+                <div id="botcreatesection" class="accordion-collapse collapse" aria-labelledby="headingBotCreate" data-bs-parent="#mainOptions">
                     <div class="accordion-body">
                             Create a new bot
                             <form>


### PR DESCRIPTION
# Goals

Round out deamon UI by allowing several actions to be taken on running daemons

# Implementation

- Add a shutdown method to spawner interface
- Implement for kubernetes and local
- Add a controller endpoint to trigger a shutdown
- Add several new actions in UI to run on daemons -- drain, reset, complete, and shutdow
- Also improve UI -- toast notifications, fluid container (to layout better), etc
- Fix bug with create bot UI now that we're using big numbers

# Demo

![dealbotactionsdemo](https://user-images.githubusercontent.com/1450680/126246975-75fd3166-f10a-430b-af0e-d3f2a383377b.gif)
