### PR TITLE
Make requested Controller changes

### DIFF
--- a/controller/app/index.js
+++ b/controller/app/index.js
@@ -126,6 +126,10 @@ function gotRegions(data) {
                 fetch(`./regions/${regionList[reg]}`, { method: "GET", headers: getHeaders()}).then((response) => response.json()).then(gotDaemons)
             })
             .appendTo($("#regionlist"));
+        $('<option/>')
+            .text(regionList[reg])
+            .val(regionList[reg])
+            .appendTo($("#newBotRegion"))
     });
 }
 
@@ -320,7 +324,7 @@ function doSubmit(e) {
                 "Miner": miner,
                 "PayloadCID": $('#newCid').val(),
                 "CARExport": false,
-                "MaxPriceAttoFIL": 20000000000,
+                "MaxPriceAttoFIL": Number($("#newRetrievalPriceFil").val())*1000000000,
             }
         } else {
             data = {
@@ -329,11 +333,12 @@ function doSubmit(e) {
                 "StartOffset": 6152, // 3 days?
                 "FastRetrieval": $('#newFast').is(':checked'),
                 "Verified": $('#newVerified').is(':checked'),
-                "MaxPriceAttoFIL": 20000000000,
+                "MaxPriceAttoFIL": Number($("#newStoragePriceFil").val())*1000000000,
             }
             if ($('#newRepeatRetAfterStore').is(':checked')) {
                 data.RetrievalSchedule = $('#newretafterstoreSchedule').val()
                 data.RetrievalScheduleLimit = $('#newretafterstoreScheduleLimit').val()
+                data.RetrievalMaxPriceAttoFIL = Number($('#newretafterstorePrice').val())*1000000000
             }
         }
 
@@ -370,10 +375,6 @@ function doCreateBot(e) {
             "address": $("#newBotWalletAddress").val(),
             "exported": $("#newBotWalletExported").val(),
         },
-        "helmchartrepourl": $("#newBotHelmChartRepoUrl").val(),
-        "helmchartversion": $("#newBotHelmChartVersion").val(),
-        "lotusdockerrepo": $("#newBotLotusDockerRepo").val(),
-        "lotusdockertag": $("#newBotLotusDockerTag").val()
     }
     fetch(url, {method: "POST", headers: getHeaders(), body: JSON.stringify(data)}).then(() => {
         successToast("Bot created!")

--- a/controller/graphql/schema.go
+++ b/controller/graphql/schema.go
@@ -1933,6 +1933,22 @@ func StorageTask__RetrievalScheduleLimit__resolve(p graphql.ResolveParams) (inte
     }
     
 }
+func StorageTask__RetrievalMaxPriceAttoFIL__resolve(p graphql.ResolveParams) (interface{}, error) {
+    ts, ok := p.Source.(tasks.StorageTask)
+    if !ok {
+        return nil, fmt.Errorf(errUnexpectedType, p.Source, "tasks.StorageTask")
+    }
+    
+    f := ts.FieldRetrievalMaxPriceAttoFIL()
+    if f.Exists() {
+        
+        return f.Must().AsInt()
+        
+    } else {
+        return nil, nil
+    }
+    
+}
 var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
     Name: "StorageTask",
     Fields: graphql.Fields{
@@ -2001,6 +2017,12 @@ var StorageTask__type = graphql.NewObject(graphql.ObjectConfig{
             Type: graphql.String,
             
             Resolve: StorageTask__RetrievalScheduleLimit__resolve,
+        },
+        "RetrievalMaxPriceAttoFIL": &graphql.Field{
+            
+            Type: graphql.Int,
+            
+            Resolve: StorageTask__RetrievalMaxPriceAttoFIL__resolve,
         },
     },
 })

--- a/controller/spawn/base.yaml
+++ b/controller/spawn/base.yaml
@@ -27,6 +27,8 @@ application:
         value: {{ .Id }}
       - name: DEALBOT_WALLET_ADDRESS
         value: {{ .Wallet.Address }}
+      - name: DEALBOT_WORKERS
+        value: "{{ .Workers }}"
       - name: DEALBOT_MIN_FIL
         value: "{{ .MinFil }}"
       - name: DEALBOT_MIN_CAP

--- a/controller/spawn/kubernetes.go
+++ b/controller/spawn/kubernetes.go
@@ -3,6 +3,7 @@ package spawn
 import (
 	"io/ioutil"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/filecoin-project/go-state-types/big"
@@ -198,6 +199,7 @@ func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
 	var minfil, mincap big.Int
 	var tags []string
 	wallet := new(Wallet)
+	var workers int
 	for _, env := range kcontainer.Env {
 		switch env.Name {
 		case "DEALBOT_TAGS":
@@ -208,14 +210,17 @@ func daemonFromRelease(r *release.Release, regionid string) (daemon *Daemon) {
 			minfil, _ = big.FromString(env.Value)
 		case "DEALBOT_MIN_CAP":
 			mincap, _ = big.FromString(env.Value)
+		case "DEALBOT_WORKERS":
+			workers, _ = strconv.Atoi(env.Value)
 		}
 	}
 	return &Daemon{
-		Id:     r.Name,
-		Region: regionid,
-		Tags:   tags,
-		Wallet: wallet,
-		MinFil: minfil,
-		MinCap: mincap,
+		Id:      r.Name,
+		Region:  regionid,
+		Tags:    tags,
+		Wallet:  wallet,
+		MinFil:  minfil,
+		MinCap:  mincap,
+		Workers: workers,
 	}
 }

--- a/controller/state/statedb.go
+++ b/controller/state/statedb.go
@@ -549,6 +549,11 @@ func (s *stateDB) Update(ctx context.Context, taskID string, req tasks.UpdateTas
 				if finalized.StorageTask.Must().Tag.Exists() {
 					tag = finalized.StorageTask.Must().Tag.Must().String()
 				}
+				var maxPrice int64 = 0
+				if finalized.StorageTask.Must().RetrievalMaxPriceAttoFIL.Exists() {
+					maxPrice = finalized.StorageTask.Must().RetrievalMaxPriceAttoFIL.Must().Int()
+				}
+
 				ret := tasks.Type.RetrievalTask.OfSchedule(
 					finalized.StorageTask.Must().Miner.String(),
 					finalized.PayloadCID.Must().String(),
@@ -556,6 +561,7 @@ func (s *stateDB) Update(ctx context.Context, taskID string, req tasks.UpdateTas
 					tag,
 					finalized.StorageTask.Must().RetrievalSchedule.Must().String(),
 					finalized.StorageTask.Must().RetrievalScheduleLimit.Must().String(),
+					maxPrice,
 				)
 				downstreamRetrieval = ret
 			}

--- a/controller/state/taskscheduler.go
+++ b/controller/state/taskscheduler.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	schedulerOwner   = "dealbot_scheduler"
-	expiredTaskOwner = "dealbot_expired"
+	schedulerOwner = "dealbot_scheduler"
 )
 
 var noEnt cron.EntryID
@@ -108,7 +107,7 @@ func (s *stateDB) runTask(taskID, schedule, limit string, expireAt time.Time, ru
 		log.Infow("scheduling expired for task", "taskID", taskID)
 		s.cronSched.Remove(jobID)
 		err = s.transact(ctx, func(tx *sql.Tx) error {
-			_, err := tx.ExecContext(ctx, updateTaskWorkedBySQL, taskID, expiredTaskOwner)
+			_, err := tx.ExecContext(ctx, deleteTaskSQL, taskID)
 			return err
 		})
 		if err != nil {

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -75,6 +75,9 @@
                             <div id="newstorage">
                                 <div class="mb-3">
                                     <select class="form-select" id="newSize">
+                                        <option value="674836480">1 GB</option>
+                                        <option value="1474836480">2 GB</option>
+                                        <option value="3174836480">4 GB</option>
                                         <option value="5474836480">8 GB</option>
                                         <option value="11474836480">16 GB</option>
                                         <option value="21474836480" selected>32 GB</option>
@@ -82,6 +85,10 @@
                                       </select>
                                       <label class="form-check-label" for="newSize">Deal Size</label>
                                 </div>
+                                <div class="mb-3">
+                                    <label for="newStoragePriceFil" class="form-label">Max Price: (nanoFIL/GB/Epoch)</label>
+                                    <input class="form-control" type="number" id="newStoragePriceFil" value="2">
+                                  </div>
                                 <div class="form-check mb-3">
                                     <input class="form-check-input" type="checkbox" value="" id="newVerified">
                                     <label class="form-check-label" for="newVerified">
@@ -106,16 +113,23 @@
                                         <input type="text" id="newretafterstoreScheduleLimit" value="720h">
                                         <label class="form-label" for="newretafterstoreScheduleLimit">Duration in which retrieval schedule is valid</label>
                                     </div>
+                                    <div class="mb-3">
+                                        <label for="newretafterstorePrice" class="form-label">Retrieval Max Price: (total price in nanoFIL)</label>
+                                        <input class="form-control" type="number" id="newretafterstorePrice" value="2">
+                                      </div>
                                 </div>
                             </div>
                             <div id="newretrieval">
                                 <div class="mb-3">
                                     <input class="form-control" value="" id="newCid">
                                     <label class="form-label" for="newCid">
-                                      Piece CID
+                                      Payload CID
                                     </label>
                                   </div>
-
+                                <div class="mb-3">
+                                    <label for="newRetrievalPriceFil" class="form-label">Max Price: (total price in nanoFIL)</label>
+                                    <input class="form-control" type="number" id="newRetrievalPriceFil" value="2">
+                                </div>
                             </div>
                             <div id="schedule">
                                 <div class="form-check form-switch">
@@ -212,8 +226,7 @@
                             Create a new bot
                             <form>
                                 <div id="botRegion">
-                                    <label for="newBotRegion" class="form-lable">Region: (required)</label>
-                                    <input class="form-control" type="text" id="newBotRegion" value="">
+                                    <select class="form-select" id="newBotRegion"></select>
                                 </div>
                                 <div id="botId">
                                     <label for="newBotId" class="form-label">Bot ID: (optional)</label>
@@ -225,7 +238,7 @@
                                 </div>
                                 <div id="botWorkers">
                                     <label for="newBotWorkers" class="form-label">Workers: (optional)</label>
-                                    <input class="form-control" type="number" id="newBotWorkers" value="1">
+                                    <input class="form-control" type="number" id="newBotWorkers" value="10">
                                 </div>
                                 <div id="botMinCap">
                                     <label for="newBotMinCap" class="form-label">Minimum Cap: (optional)</label>

--- a/tasks/gen.go
+++ b/tasks/gen.go
@@ -108,6 +108,7 @@ func main() {
 		schema.SpawnStructField("Tag", "String", true, true),
 		schema.SpawnStructField("RetrievalSchedule", "String", true, true),
 		schema.SpawnStructField("RetrievalScheduleLimit", "String", true, true),
+		schema.SpawnStructField("RetrievalMaxPriceAttoFIL", "Int", true, true),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
 
 	ts.Accumulate(schema.SpawnStruct("Task", []schema.StructField{

--- a/tasks/ipldsch_satisfaction.go
+++ b/tasks/ipldsch_satisfaction.go
@@ -16368,6 +16368,9 @@ func (n _StorageTask) FieldRetrievalSchedule() MaybeString {
 func (n _StorageTask) FieldRetrievalScheduleLimit() MaybeString {
 	return &n.RetrievalScheduleLimit
 }
+func (n _StorageTask) FieldRetrievalMaxPriceAttoFIL() MaybeInt {
+	return &n.RetrievalMaxPriceAttoFIL
+}
 type _StorageTask__Maybe struct {
 	m schema.Maybe
 	v StorageTask
@@ -16413,6 +16416,7 @@ var (
 	fieldName__StorageTask_Tag = _String{"Tag"}
 	fieldName__StorageTask_RetrievalSchedule = _String{"RetrievalSchedule"}
 	fieldName__StorageTask_RetrievalScheduleLimit = _String{"RetrievalScheduleLimit"}
+	fieldName__StorageTask_RetrievalMaxPriceAttoFIL = _String{"RetrievalMaxPriceAttoFIL"}
 )
 var _ ipld.Node = (StorageTask)(&_StorageTask{})
 var _ schema.TypedNode = (StorageTask)(&_StorageTask{})
@@ -16473,6 +16477,14 @@ func (n StorageTask) LookupByString(key string) (ipld.Node, error) {
 			return ipld.Null, nil
 		}
 		return n.RetrievalScheduleLimit.v, nil
+	case "RetrievalMaxPriceAttoFIL":
+		if n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Absent {
+			return ipld.Absent, nil
+		}
+		if n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.RetrievalMaxPriceAttoFIL.v, nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -16500,7 +16512,7 @@ type _StorageTask__MapItr struct {
 }
 
 func (itr *_StorageTask__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
-	if itr.idx >= 11 {
+	if itr.idx >= 12 {
 		return nil, nil, ipld.ErrIteratorOverread{}
 	}
 	switch itr.idx {
@@ -16577,6 +16589,17 @@ func (itr *_StorageTask__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 			break
 		}
 		v = itr.n.RetrievalScheduleLimit.v
+	case 11:
+		k = &fieldName__StorageTask_RetrievalMaxPriceAttoFIL
+		if itr.n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Absent {
+			v = ipld.Absent
+			break
+		}
+		if itr.n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.RetrievalMaxPriceAttoFIL.v
 	default:
 		panic("unreachable")
 	}
@@ -16584,14 +16607,14 @@ func (itr *_StorageTask__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 	return
 }
 func (itr *_StorageTask__MapItr) Done() bool {
-	return itr.idx >= 11
+	return itr.idx >= 12
 }
 
 func (StorageTask) ListIterator() ipld.ListIterator {
 	return nil
 }
 func (StorageTask) Length() int64 {
-	return 11
+	return 12
 }
 func (StorageTask) IsAbsent() bool {
 	return false
@@ -16660,6 +16683,7 @@ type _StorageTask__Assembler struct {
 	ca_Tag _String__Assembler
 	ca_RetrievalSchedule _String__Assembler
 	ca_RetrievalScheduleLimit _String__Assembler
+	ca_RetrievalMaxPriceAttoFIL _Int__Assembler
 	}
 
 func (na *_StorageTask__Assembler) reset() {
@@ -16676,6 +16700,7 @@ func (na *_StorageTask__Assembler) reset() {
 	na.ca_Tag.reset()
 	na.ca_RetrievalSchedule.reset()
 	na.ca_RetrievalScheduleLimit.reset()
+	na.ca_RetrievalMaxPriceAttoFIL.reset()
 }
 
 var (
@@ -16690,6 +16715,7 @@ var (
 	fieldBit__StorageTask_Tag = 1 << 8
 	fieldBit__StorageTask_RetrievalSchedule = 1 << 9
 	fieldBit__StorageTask_RetrievalScheduleLimit = 1 << 10
+	fieldBit__StorageTask_RetrievalMaxPriceAttoFIL = 1 << 11
 	fieldBits__StorageTask_sufficient = 0 + 1 << 0 + 1 << 1 + 1 << 2 + 1 << 3 + 1 << 4 + 1 << 5
 )
 func (na *_StorageTask__Assembler) BeginMap(int64) (ipld.MapAssembler, error) {
@@ -16903,6 +16929,18 @@ func (ma *_StorageTask__Assembler) valueFinishTidy() bool {
 		default:
 			return false
 		}
+	case 11:
+		switch ma.w.RetrievalMaxPriceAttoFIL.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
+		case schema.Maybe_Value:
+			ma.w.RetrievalMaxPriceAttoFIL.v = ma.ca_RetrievalMaxPriceAttoFIL.w
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
 	default:
 		panic("unreachable")
 	}
@@ -17038,6 +17076,17 @@ func (ma *_StorageTask__Assembler) AssembleEntry(k string) (ipld.NodeAssembler, 
 		ma.ca_RetrievalScheduleLimit.m = &ma.w.RetrievalScheduleLimit.m
 		ma.w.RetrievalScheduleLimit.m = allowNull
 		return &ma.ca_RetrievalScheduleLimit, nil
+	case "RetrievalMaxPriceAttoFIL":
+		if ma.s & fieldBit__StorageTask_RetrievalMaxPriceAttoFIL != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__StorageTask_RetrievalMaxPriceAttoFIL}
+		}
+		ma.s += fieldBit__StorageTask_RetrievalMaxPriceAttoFIL
+		ma.state = maState_midValue
+		ma.f = 11
+		ma.ca_RetrievalMaxPriceAttoFIL.w = ma.w.RetrievalMaxPriceAttoFIL.v
+		ma.ca_RetrievalMaxPriceAttoFIL.m = &ma.w.RetrievalMaxPriceAttoFIL.m
+		ma.w.RetrievalMaxPriceAttoFIL.m = allowNull
+		return &ma.ca_RetrievalMaxPriceAttoFIL, nil
 	default:
 		return nil, ipld.ErrInvalidKey{TypeName:"tasks.StorageTask", Key:&_String{k}}
 	}
@@ -17124,6 +17173,11 @@ func (ma *_StorageTask__Assembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_RetrievalScheduleLimit.m = &ma.w.RetrievalScheduleLimit.m
 		ma.w.RetrievalScheduleLimit.m = allowNull
 		return &ma.ca_RetrievalScheduleLimit
+	case 11:
+		ma.ca_RetrievalMaxPriceAttoFIL.w = ma.w.RetrievalMaxPriceAttoFIL.v
+		ma.ca_RetrievalMaxPriceAttoFIL.m = &ma.w.RetrievalMaxPriceAttoFIL.m
+		ma.w.RetrievalMaxPriceAttoFIL.m = allowNull
+		return &ma.ca_RetrievalMaxPriceAttoFIL
 	default:
 		panic("unreachable")
 	}
@@ -17276,6 +17330,13 @@ func (ka *_StorageTask__KeyAssembler) AssignString(k string) error {
 		ka.s += fieldBit__StorageTask_RetrievalScheduleLimit
 		ka.state = maState_expectValue
 		ka.f = 10
+	case "RetrievalMaxPriceAttoFIL":
+		if ka.s & fieldBit__StorageTask_RetrievalMaxPriceAttoFIL != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__StorageTask_RetrievalMaxPriceAttoFIL}
+		}
+		ka.s += fieldBit__StorageTask_RetrievalMaxPriceAttoFIL
+		ka.state = maState_expectValue
+		ka.f = 11
 	default:
 		return ipld.ErrInvalidKey{TypeName:"tasks.StorageTask", Key:&_String{k}}
 	}
@@ -17316,6 +17377,7 @@ var (
 	fieldName__StorageTask_Tag_serial = _String{"Tag"}
 	fieldName__StorageTask_RetrievalSchedule_serial = _String{"RetrievalSchedule"}
 	fieldName__StorageTask_RetrievalScheduleLimit_serial = _String{"RetrievalScheduleLimit"}
+	fieldName__StorageTask_RetrievalMaxPriceAttoFIL_serial = _String{"RetrievalMaxPriceAttoFIL"}
 )
 var _ ipld.Node = &_StorageTask__Repr{}
 func (_StorageTask__Repr) Kind() ipld.Kind {
@@ -17375,6 +17437,14 @@ func (n *_StorageTask__Repr) LookupByString(key string) (ipld.Node, error) {
 			return ipld.Null, nil
 		}
 		return n.RetrievalScheduleLimit.v.Representation(), nil
+	case "RetrievalMaxPriceAttoFIL":
+		if n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Absent {
+			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+		}
+		if n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.RetrievalMaxPriceAttoFIL.v.Representation(), nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -17393,7 +17463,12 @@ func (n _StorageTask__Repr) LookupBySegment(seg ipld.PathSegment) (ipld.Node, er
 	return n.LookupByString(seg.String())
 }
 func (n *_StorageTask__Repr) MapIterator() ipld.MapIterator {
-	end := 11
+	end := 12
+	if n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Absent {
+		end = 11
+	} else {
+		goto done
+	}
 	if n.RetrievalScheduleLimit.m == schema.Maybe_Absent {
 		end = 10
 	} else {
@@ -17430,7 +17505,7 @@ type _StorageTask__ReprMapItr struct {
 }
 
 func (itr *_StorageTask__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
-advance:if itr.idx >= 11 {
+advance:if itr.idx >= 12 {
 		return nil, nil, ipld.ErrIteratorOverread{}
 	}
 	switch itr.idx {
@@ -17507,6 +17582,17 @@ advance:if itr.idx >= 11 {
 			break
 		}
 		v = itr.n.RetrievalScheduleLimit.v.Representation()
+	case 11:
+		k = &fieldName__StorageTask_RetrievalMaxPriceAttoFIL_serial
+		if itr.n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Absent {
+			itr.idx++
+			goto advance
+		}
+		if itr.n.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.RetrievalMaxPriceAttoFIL.v.Representation()
 	default:
 		panic("unreachable")
 	}
@@ -17520,7 +17606,7 @@ func (_StorageTask__Repr) ListIterator() ipld.ListIterator {
 	return nil
 }
 func (rn *_StorageTask__Repr) Length() int64 {
-	l := 11
+	l := 12
 	if rn.Schedule.m == schema.Maybe_Absent {
 		l--
 	}
@@ -17534,6 +17620,9 @@ func (rn *_StorageTask__Repr) Length() int64 {
 		l--
 	}
 	if rn.RetrievalScheduleLimit.m == schema.Maybe_Absent {
+		l--
+	}
+	if rn.RetrievalMaxPriceAttoFIL.m == schema.Maybe_Absent {
 		l--
 	}
 	return int64(l)
@@ -17605,6 +17694,7 @@ type _StorageTask__ReprAssembler struct {
 	ca_Tag _String__ReprAssembler
 	ca_RetrievalSchedule _String__ReprAssembler
 	ca_RetrievalScheduleLimit _String__ReprAssembler
+	ca_RetrievalMaxPriceAttoFIL _Int__ReprAssembler
 	}
 
 func (na *_StorageTask__ReprAssembler) reset() {
@@ -17621,6 +17711,7 @@ func (na *_StorageTask__ReprAssembler) reset() {
 	na.ca_Tag.reset()
 	na.ca_RetrievalSchedule.reset()
 	na.ca_RetrievalScheduleLimit.reset()
+	na.ca_RetrievalMaxPriceAttoFIL.reset()
 }
 func (na *_StorageTask__ReprAssembler) BeginMap(int64) (ipld.MapAssembler, error) {
 	switch *na.m {
@@ -17821,6 +17912,18 @@ func (ma *_StorageTask__ReprAssembler) valueFinishTidy() bool {
 		default:
 			return false
 		}
+	case 11:
+		switch ma.w.RetrievalMaxPriceAttoFIL.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
+		case schema.Maybe_Value:
+			ma.w.RetrievalMaxPriceAttoFIL.v = ma.ca_RetrievalMaxPriceAttoFIL.w
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
 	default:
 		panic("unreachable")
 	}
@@ -17956,6 +18059,17 @@ func (ma *_StorageTask__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssembl
 		ma.ca_RetrievalScheduleLimit.m = &ma.w.RetrievalScheduleLimit.m
 		ma.w.RetrievalScheduleLimit.m = allowNull
 		return &ma.ca_RetrievalScheduleLimit, nil
+	case "RetrievalMaxPriceAttoFIL":
+		if ma.s & fieldBit__StorageTask_RetrievalMaxPriceAttoFIL != 0 {
+			return nil, ipld.ErrRepeatedMapKey{&fieldName__StorageTask_RetrievalMaxPriceAttoFIL_serial}
+		}
+		ma.s += fieldBit__StorageTask_RetrievalMaxPriceAttoFIL
+		ma.state = maState_midValue
+		ma.f = 11
+		ma.ca_RetrievalMaxPriceAttoFIL.w = ma.w.RetrievalMaxPriceAttoFIL.v
+		ma.ca_RetrievalMaxPriceAttoFIL.m = &ma.w.RetrievalMaxPriceAttoFIL.m
+		ma.w.RetrievalMaxPriceAttoFIL.m = allowNull
+		return &ma.ca_RetrievalMaxPriceAttoFIL, nil
 	default:
 		return nil, ipld.ErrInvalidKey{TypeName:"tasks.StorageTask.Repr", Key:&_String{k}}
 	}
@@ -18042,6 +18156,11 @@ func (ma *_StorageTask__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 		ma.ca_RetrievalScheduleLimit.m = &ma.w.RetrievalScheduleLimit.m
 		ma.w.RetrievalScheduleLimit.m = allowNull
 		return &ma.ca_RetrievalScheduleLimit
+	case 11:
+		ma.ca_RetrievalMaxPriceAttoFIL.w = ma.w.RetrievalMaxPriceAttoFIL.v
+		ma.ca_RetrievalMaxPriceAttoFIL.m = &ma.w.RetrievalMaxPriceAttoFIL.m
+		ma.w.RetrievalMaxPriceAttoFIL.m = allowNull
+		return &ma.ca_RetrievalMaxPriceAttoFIL
 	default:
 		panic("unreachable")
 	}
@@ -18194,6 +18313,13 @@ func (ka *_StorageTask__ReprKeyAssembler) AssignString(k string) error {
 		ka.s += fieldBit__StorageTask_RetrievalScheduleLimit
 		ka.state = maState_expectValue
 		ka.f = 10
+	case "RetrievalMaxPriceAttoFIL":
+		if ka.s & fieldBit__StorageTask_RetrievalMaxPriceAttoFIL != 0 {
+			return ipld.ErrRepeatedMapKey{&fieldName__StorageTask_RetrievalMaxPriceAttoFIL_serial}
+		}
+		ka.s += fieldBit__StorageTask_RetrievalMaxPriceAttoFIL
+		ka.state = maState_expectValue
+		ka.f = 11
 	default:
 		return ipld.ErrInvalidKey{TypeName:"tasks.StorageTask.Repr", Key:&_String{k}}
 	}

--- a/tasks/ipldsch_types.go
+++ b/tasks/ipldsch_types.go
@@ -265,6 +265,7 @@ type _StorageTask struct {
 	Tag _String__Maybe
 	RetrievalSchedule _String__Maybe
 	RetrievalScheduleLimit _String__Maybe
+	RetrievalMaxPriceAttoFIL _Int__Maybe
 }
 
 // String matches the IPLD Schema type "String".  It has string kind.

--- a/tasks/retrieval_deal.go
+++ b/tasks/retrieval_deal.go
@@ -340,14 +340,15 @@ func (rp _RetrievalTask__Prototype) Of(minerParam string, payloadCid string, car
 	return &rt
 }
 
-func (rp _RetrievalTask__Prototype) OfSchedule(minerParam string, payloadCid string, carExport bool, tag string, schedule string, scheduleLimit string) RetrievalTask {
+func (rp _RetrievalTask__Prototype) OfSchedule(minerParam string, payloadCid string, carExport bool, tag string, schedule string, scheduleLimit string, maxPrice int64) RetrievalTask {
 	rt := _RetrievalTask{
-		Miner:         _String{minerParam},
-		PayloadCID:    _String{payloadCid},
-		CARExport:     _Bool{carExport},
-		Tag:           asStrM(tag),
-		Schedule:      asStrM(schedule),
-		ScheduleLimit: asStrM(scheduleLimit),
+		Miner:           _String{minerParam},
+		PayloadCID:      _String{payloadCid},
+		CARExport:       _Bool{carExport},
+		Tag:             asStrM(tag),
+		Schedule:        asStrM(schedule),
+		ScheduleLimit:   asStrM(scheduleLimit),
+		MaxPriceAttoFIL: asIntM(maxPrice),
 	}
 	return &rt
 }

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -436,6 +436,9 @@ func mktime(t time.Time) _Time {
 func asStrM(s string) _String__Maybe {
 	return _String__Maybe{m: schema.Maybe_Value, v: &_String{s}}
 }
+func asIntM(i int64) _Int__Maybe {
+	return _Int__Maybe{m: schema.Maybe_Value, v: &_Int{i}}
+}
 
 func toStageDetails(stage *storagemarket.DealStage) StageDetails {
 	logs := make([]_Logs, 0, len(stage.Logs))


### PR DESCRIPTION
# Goals

Address all P1s in #311 other than dealbot status (draining, in progress, etc)

# Implementation

- Add RetrievalMaxPriceToATTOFil for storage deals to set max price on retrieval
- Expose MaxPrice UI for storage and retrieval (and retrieval after storage)
- Make sure RetrievalMaxPriceToAttoFil is transferred to retrieval deal
- Actually use number passed in Dealbot Workers -- and set default to 10
- Transmit Dealbot Workers count when querying daemons (not listed in UI ATM)
- Delete expired scheduled tasks automatically so they don't show up in deals list
- Update region field in Create Bot to drop down
- Add option for 1GB, 2GB, 4GB deals