### PR TITLE
Fix stage timeouts in storage deal

### DIFF
--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -396,6 +396,8 @@ func (de *storageDealExecutor) executeAndMonitorDeal(ctx context.Context, update
 				if err != nil {
 					return err
 				}
+
+				stage = newState
 			}
 
 			// deal is on chain, exit successfully


### PR DESCRIPTION
# Goals

We were not updating the stage used to process timeouts in storage deal. This fixes the problem.

# Implementation

Update stage var when we update the stage generally, so that state timeouts are processed correctly.