### PR TITLE
No default helm chart version

### DIFF
--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -265,7 +265,7 @@
                                 <h4>Deployment Parameters</h3>
                                 <div id="botHelmChartVersion">
                                     <label for="newBotHelmChartVersion" class="form-label">Helm chart version of lotus-bundle. Leave blank to use latest</label>
-                                    <input class="form-control" type="text" id="newBotHelmChartVersion" value="0.0.4">
+                                    <input class="form-control" type="text" id="newBotHelmChartVersion" value="" placeholder="0.0.6">
                                 </div>
                                 <div id="botHelmChartRepoUrl">
                                     <label for="newBotHelmChartRepoUrl" class="form-label">Helm chart repo URL for lotus-bundle (optional)</label>


### PR DESCRIPTION
# Goals

Don't enter a default helm chart version so the regular version is simply "latest"

# Implementation

- convert from value to placeholder
- update placeholder to latest