### PR TITLE
update helm chart

### DIFF
--- a/controller/spawn/base.yaml
+++ b/controller/spawn/base.yaml
@@ -71,6 +71,8 @@ application:
     - mount: /shared
       volume:
         - name: shared-volume
+          chownLotus: true
+          subdirPerRelease: true
           persistentVolumeClaim:
               claimName: chain-exports
 

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -265,7 +265,7 @@
                                 <h4>Deployment Parameters</h3>
                                 <div id="botHelmChartVersion">
                                     <label for="newBotHelmChartVersion" class="form-label">Helm chart version of lotus-bundle. Leave blank to use latest</label>
-                                    <input class="form-control" type="text" id="newBotHelmChartVersion" value="" placeholder="0.0.6">
+                                    <input class="form-control" type="text" id="newBotHelmChartVersion" value="" placeholder="0.0.9">
                                 </div>
                                 <div id="botHelmChartRepoUrl">
                                     <label for="newBotHelmChartRepoUrl" class="form-label">Helm chart repo URL for lotus-bundle (optional)</label>


### PR DESCRIPTION
The new chart includes jaeger tracing for the lotus daemon, and includes
an option to mount a subdirectory on shared storage for isolation
purposes.

Also, the default lotus repo will be 4T in size instead of the current 2T