### PR TITLE
cache 2kb proof params for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,20 @@ commands:
     steps:
       - run:
           command: echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin
+  download-params:
+    steps:
+      - restore_cache:
+          name: Restore parameters cache
+          keys:
+            - 'v28-2kb-lotus-params'
+          paths:
+            - /var/tmp/filecoin-proof-parameters/
+      - run:  lotus fetch-params 2048
+      - save_cache:
+          name: Save parameters cache
+          key: 'v28-2kb-lotus-params'
+          paths:
+            - /var/tmp/filecoin-proof-parameters/
 
 jobs:
   build-and-test:
@@ -51,6 +65,7 @@ jobs:
           command: dockerize -wait tcp://127.0.0.1:5432 -timeout 1m
       - checkout-dealbot
       - install-lotus
+      - download-params
       - test-integration-dealbot
   build-push:
     machine:


### PR DESCRIPTION
This PR is adding a step to `download-params` before integration tests run. As soon as this step completes once, the cache is there and `lotus fetch-params 2048` exits immediately.