### PR TITLE
Upgrade to latest go-legs and log missing listen addrs

### DIFF
--- a/controller/state/libp2p.go
+++ b/controller/state/libp2p.go
@@ -76,17 +76,19 @@ func NewHost(priv crypto.PrivKey, listenAddrs []multiaddr.Multiaddr) (host.Host,
 		}
 	}
 
-	if err := net.Listen(listenAddrs...); err != nil {
+	if len(listenAddrs) == 0 {
+		log.Warn("no listen addresses are specified for libp2p host")
+	} else if err := net.Listen(listenAddrs...); err != nil {
 		return nil, err
 	}
 
-	host, err := basichost.NewHost(net, &basichost.HostOpts{})
+	h, err := basichost.NewHost(net, &basichost.HostOpts{})
 	if err != nil {
 		return nil, err
 	}
 
-	host.Start()
-	return host, nil
+	h.Start()
+	return h, nil
 }
 
 func bootstrapHost(host host.Host, btstrp []peer.AddrInfo) (io.Closer, error) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-fil-markets v1.19.0
 	github.com/filecoin-project/go-jsonrpc v0.1.5
-	github.com/filecoin-project/go-legs v0.2.8
+	github.com/filecoin-project/go-legs v0.3.1
 	github.com/filecoin-project/go-state-types v0.1.3
 	github.com/filecoin-project/lotus v1.13.3-0.20220208105256-b38adaa73640
 	github.com/golang-migrate/migrate/v4 v4.14.2-0.20210511063805-2e7358e012a6

--- a/go.sum
+++ b/go.sum
@@ -574,6 +574,8 @@ github.com/filecoin-project/go-jsonrpc v0.1.5 h1:ckxqZ09ivBAVf5CSmxxrqqNHC7PJm3G
 github.com/filecoin-project/go-jsonrpc v0.1.5/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
 github.com/filecoin-project/go-legs v0.2.8 h1:l76g9Yi7YzxNHwe60jPmQiezUUF0TMjqB/NP4+f23vU=
 github.com/filecoin-project/go-legs v0.2.8/go.mod h1:NrdELuDbtAH8/xqRMgyOYms67aliQajExInLS6g8zFM=
+github.com/filecoin-project/go-legs v0.3.1 h1:W6dD3rzZIh4gp78wgajD2Et3Jf8etcD+OsDiyfih4sQ=
+github.com/filecoin-project/go-legs v0.3.1/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
 github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.mod h1:mPn+LRRd5gEKNAtc+r3ScpW2JRU/pj4NBKdADYWHiak=
 github.com/filecoin-project/go-padreader v0.0.0-20210723183308-812a16dc01b1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=
 github.com/filecoin-project/go-padreader v0.0.1 h1:8h2tVy5HpoNbr2gBRr+WD6zV6VD6XHig+ynSGJg8ZOs=


### PR DESCRIPTION
Upgrade to the latest go-legs so that the breaking changes in latest
go-legs are integrated in dealbot.

Add logging that warns if no host listen address is configured.