### PR TITLE
Bump helm chart version number to include libp2p service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ workflows:
       - deploy-lotusinfra:
           name: deploy-nerpanet-controller
           chart: filecoin/dealbot
-          chart_version: 0.0.12
+          chart_version: 0.0.13
           circle_context: sentinel-staging-deploy
           kubernetes_cluster: mainnet-us-east-2-dev-eks
           aws_region: us-east-2
@@ -157,7 +157,7 @@ workflows:
       - deploy-lotusinfra:
           name: deploy-mainnet-controller
           chart: filecoin/dealbot
-          chart_version: 0.0.12
+          chart_version: 0.0.13
           circle_context: filecoin-mainnet-aws
           kubernetes_cluster: mainnet-us-east-1-eks
           aws_region: us-east-1


### PR DESCRIPTION
Bump the helm chart version number to create a service that exposes
libp2p node statrted up in controller used for syncing chain of updates
announced by go-legs. The K8S service is added here:
 - https://github.com/filecoin-project/helm-charts/pull/124

Relates to:
 - https://github.com/filecoin-project/dealbot/issues/342