### PR TITLE
Add option to specify external addresses advertised by legs

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -244,6 +244,11 @@ var ControllerFlags = []cli.Flag{
 		Usage:   "libp2p addrinfos to use for bootstrapping",
 		EnvVars: []string{"DEALBOT_LIBP2P_BOOTSTRAP_ADDRINFO"},
 	}),
+	altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		Name:    "legs-advertised-addrs",
+		Usage:   "Multiaddrs to advertise in legs messages. If unset, libp2p listen address are used instead",
+		EnvVars: []string{"DEALBOT_LEGS_ADDRS"},
+	}),
 	altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "graphql",
 		Usage:   "host:port to bind graphql server on",

--- a/controller/publisher/options.go
+++ b/controller/publisher/options.go
@@ -5,6 +5,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 )
 
 type (
@@ -15,6 +16,7 @@ type (
 		h         host.Host
 		btstrpCfg *bootstrap.BootstrapConfig
 		topic     string
+		extAddrs  []multiaddr.Multiaddr
 	}
 )
 
@@ -33,6 +35,9 @@ func apply(o ...Option) (*options, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+	if len(opts.extAddrs) == 0 {
+		opts.extAddrs = opts.h.Addrs()
 	}
 	return opts, nil
 }
@@ -72,6 +77,16 @@ func WithHost(h host.Host) Option {
 func WithTopic(topic string) Option {
 	return func(o *options) error {
 		o.topic = topic
+		return nil
+	}
+}
+
+// WithExternalAddrs sets the addresses to include in published legs messages as the address on which
+// the hsot can be reached.
+// Defaults to host listen addresses.
+func WithExternalAddrs(addrs []multiaddr.Multiaddr) Option {
+	return func(o *options) error {
+		o.extAddrs = addrs
 		return nil
 	}
 }

--- a/controller/publisher/pando_publisher.go
+++ b/controller/publisher/pando_publisher.go
@@ -111,7 +111,7 @@ func (p *PandoPublisher) Start(_ context.Context) (err error) {
 		return err
 	}
 
-	log.Info("Started pando publisher")
+	log.Infow("Started pando publisher", "extAddrs", p.opts.extAddrs)
 	return nil
 }
 
@@ -175,12 +175,12 @@ func (p *PandoPublisher) Publish(ctx context.Context, c cid.Cid) error {
 	}
 
 	// Announce the latest
-	if err := p.pub.UpdateRoot(ctx, latest); err != nil {
+	if err := p.pub.UpdateRootWithAddrs(ctx, latest, p.opts.extAddrs); err != nil {
 		log.Errorw("Failed to update the latest legs root", "err", err)
 		return err
 	}
 
-	log.Info("Published the latest root successfully")
+	log.Infow("Published the latest root successfully", "extAddrs", p.opts.extAddrs)
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-fil-markets v1.19.0
 	github.com/filecoin-project/go-jsonrpc v0.1.5
-	github.com/filecoin-project/go-legs v0.3.1
+	github.com/filecoin-project/go-legs v0.3.7
 	github.com/filecoin-project/go-state-types v0.1.3
 	github.com/filecoin-project/lotus v1.13.3-0.20220208105256-b38adaa73640
 	github.com/golang-migrate/migrate/v4 v4.14.2-0.20210511063805-2e7358e012a6
@@ -323,7 +323,7 @@ require (
 	github.com/valyala/fasttemplate v1.0.1 // indirect
 	github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a // indirect
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba // indirect
-	github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008 // indirect
+	github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831 // indirect
 	github.com/whyrusleeping/ledger-filecoin-go v0.9.1-0.20201010031517-c3dcc1bddce4 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect

--- a/go.sum
+++ b/go.sum
@@ -580,8 +580,9 @@ github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0/go.mod h1:bxmzgT8tmeVQA1/gvBw
 github.com/filecoin-project/go-indexer-core v0.2.7/go.mod h1:6YD7KwDOQ+03DdAitviL7h1fksIU6a4j52yPnA/E1PU=
 github.com/filecoin-project/go-jsonrpc v0.1.5 h1:ckxqZ09ivBAVf5CSmxxrqqNHC7PJm3GYGtYKiNQ+vGk=
 github.com/filecoin-project/go-jsonrpc v0.1.5/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
-github.com/filecoin-project/go-legs v0.3.1 h1:W6dD3rzZIh4gp78wgajD2Et3Jf8etcD+OsDiyfih4sQ=
 github.com/filecoin-project/go-legs v0.3.1/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
+github.com/filecoin-project/go-legs v0.3.7 h1:yfm7fx+iy1nPtgPEQ6kQjvhoJOVbXide50STYdy+yos=
+github.com/filecoin-project/go-legs v0.3.7/go.mod h1:pgekGm8/gKY5zCtQ/qGAoSjGP92wTLFqpO3GPHeu8YU=
 github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.mod h1:mPn+LRRd5gEKNAtc+r3ScpW2JRU/pj4NBKdADYWHiak=
 github.com/filecoin-project/go-padreader v0.0.0-20210723183308-812a16dc01b1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=
 github.com/filecoin-project/go-padreader v0.0.1 h1:8h2tVy5HpoNbr2gBRr+WD6zV6VD6XHig+ynSGJg8ZOs=
@@ -2624,8 +2625,9 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20210118024343-169e9d70c0c2/go.mod h1:f
 github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20210713220151-be142a5ae1a8/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008 h1:7WtW9D9VGpmRLuQmrPy2JobUNdka95z3MKEVpELtOjo=
 github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831 h1:9blPRrm7ebDqDm6nHXXzCSru+sp20gcA3CLu+G/kHUc=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-ctrlnet v0.0.0-20180313164037-f564fbbdaa95/go.mod h1:SJqKCCPXRfBFCwXjfNT/skfsceF7+MBFLI2OrvuRA7g=

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_bootstraeeepHost(t *testing.T) {
+	peerid := "12D3KooWMm4sgwMsbzdGnLNhQv4dgMvqyp2JAAPHJHtRWVvjG8rn"
+	//addrinfo := "/dns/adbbccfa94ea64c40b59dc34ccf16219-dfb84bf0fd1db508.elb.us-east-1.amazonaws.com/tcp/8762/p2p/" + peerid
+	addrinfo := "/dns/dealbot-mainnet-l.mainnet-us-east-1.filops.net/tcp/8762/p2p/" + peerid
+	//addrinfo := "/ip4/184.73.21.166/tcp/40664/p2p/" + peerid
+	//peerid := "12D3KooWNU48MUrPEoYh77k99RbskgftfmSm3CdkonijcM5VehS9"
+	//addrinfo := "/ip4/52.14.211.248/tcp/9013/p2p/" + peerid
+	fromString, err := peer.AddrInfoFromString(addrinfo)
+	require.NoError(t, err)
+	host, err := libp2p.New()
+	require.NoError(t, err)
+	err = host.Connect(context.Background(), *fromString)
+	require.NoError(t, err)
+	idFromString, err := peer.Decode(peerid)
+	require.NoError(t, err)
+	protocols, err := host.Peerstore().GetProtocols(idFromString)
+	require.NoError(t, err)
+	for _, protocol := range protocols {
+		fmt.Println(protocol)
+	}
+
+	//decodeString, err := base64.StdEncoding.DecodeString("CAESQKkp+yk6YH0UdJ5jlZzHIKdgT2yRzDgkGSlEzVH56xTWsXPyPN0xmh2sN6ElkZ1Y94EbT/vAzcX4Qz3xD+Ik29s=")
+	//require.NoError(t, err)
+	//
+	//key, err := crypto.UnmarshalPrivateKey(decodeString)
+	//require.NoError(t, err)
+	//
+	//fmt.Println(key.GetPublic())
+}


### PR DESCRIPTION
Add an option to explicitly set the external addresses advertised as
part of legs messages on gossipsub.

Upgrade legs to fix the bug in supplying DNS addresses.