### PR TITLE
Move retrieval to v1 api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install ocl-icd-opencl-dev libhwloc-dev
-      - run: git clone -b v1.13.0 --depth=1 https://github.com/filecoin-project/lotus /tmp/lotus
+      - run: git clone -b v1.14.3 --depth=1 https://github.com/filecoin-project/lotus /tmp/lotus
       - run: cd /tmp/lotus && git submodule update --init --depth=1
       - run: cd /tmp/lotus && make debug && sudo make install
       - run: cd /tmp/lotus && sudo cp lotus-seed /usr/local/bin

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -11,7 +11,7 @@ import (
 	"github.com/filecoin-project/dealbot/controller/client"
 	"github.com/filecoin-project/dealbot/lotus"
 	"github.com/filecoin-project/dealbot/tasks"
-	"github.com/filecoin-project/lotus/api/v0api"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/google/uuid"
 	"github.com/urfave/cli/v2"
 
@@ -34,17 +34,17 @@ type apiClient interface {
 }
 
 type taskExecutor interface {
-	MakeStorageDeal(ctx context.Context, config tasks.NodeConfig, node v0api.FullNode, task tasks.StorageTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error
-	MakeRetrievalDeal(ctx context.Context, config tasks.NodeConfig, node v0api.FullNode, task tasks.RetrievalTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error
+	MakeStorageDeal(ctx context.Context, config tasks.NodeConfig, node api.FullNode, task tasks.StorageTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error
+	MakeRetrievalDeal(ctx context.Context, config tasks.NodeConfig, node api.FullNode, task tasks.RetrievalTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error
 }
 
 type defaultTaskExecutor struct{}
 
-func (defaultTaskExecutor) MakeStorageDeal(ctx context.Context, config tasks.NodeConfig, node v0api.FullNode, task tasks.StorageTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
+func (defaultTaskExecutor) MakeStorageDeal(ctx context.Context, config tasks.NodeConfig, node api.FullNode, task tasks.StorageTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
 	return tasks.MakeStorageDeal(ctx, config, node, task, updateStage, log, stageTimeouts, releaseWorker)
 }
 
-func (defaultTaskExecutor) MakeRetrievalDeal(ctx context.Context, config tasks.NodeConfig, node v0api.FullNode, task tasks.RetrievalTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
+func (defaultTaskExecutor) MakeRetrievalDeal(ctx context.Context, config tasks.NodeConfig, node api.FullNode, task tasks.RetrievalTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
 	return tasks.MakeRetrievalDeal(ctx, config, node, task, updateStage, log, stageTimeouts, releaseWorker)
 }
 
@@ -58,7 +58,7 @@ type Engine struct {
 	stageTimeouts map[string]time.Duration
 
 	// depedencies
-	node         v0api.FullNode
+	node         api.FullNode
 	nodeConfig   tasks.NodeConfig
 	closer       lotus.NodeCloser
 	client       apiClient
@@ -108,7 +108,7 @@ func new(
 	host string,
 	stageTimeouts map[string]time.Duration,
 	tags []string,
-	node v0api.FullNode,
+	node api.FullNode,
 	nodeConfig tasks.NodeConfig,
 	closer lotus.NodeCloser,
 	client apiClient,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/api/v0api"
-	"github.com/filecoin-project/lotus/api/v0api/v0mocks"
+	"github.com/filecoin-project/lotus/api/mocks"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -149,7 +148,7 @@ func TestEngineTiming(t *testing.T) {
 			// depedencies
 			walletAddress := address.TestAddress
 			head := &types.TipSet{}
-			node := v0mocks.NewMockFullNode(ctrl)
+			node := mocks.NewMockFullNode(ctrl)
 			ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
 			amt := abi.NewTokenAmount(1000000000000)
 			node.EXPECT().Version(gomock.AssignableToTypeOf(ctxType)).Return(api.APIVersion{
@@ -347,7 +346,7 @@ func (tte *testTaskExecutor) runTask(ctx context.Context, index int, releaseWork
 	return nil
 }
 
-func (tte *testTaskExecutor) MakeStorageDeal(ctx context.Context, config tasks.NodeConfig, node v0api.FullNode, task tasks.StorageTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
+func (tte *testTaskExecutor) MakeStorageDeal(ctx context.Context, config tasks.NodeConfig, node api.FullNode, task tasks.StorageTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
 	tag := task.Tag.Must().String()
 	index, err := strconv.Atoi(tag)
 	if err != nil {
@@ -359,7 +358,7 @@ func (tte *testTaskExecutor) MakeStorageDeal(ctx context.Context, config tasks.N
 	return tte.runTask(ctx, index, releaseWorker)
 }
 
-func (tte *testTaskExecutor) MakeRetrievalDeal(ctx context.Context, config tasks.NodeConfig, node v0api.FullNode, task tasks.RetrievalTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
+func (tte *testTaskExecutor) MakeRetrievalDeal(ctx context.Context, config tasks.NodeConfig, node api.FullNode, task tasks.RetrievalTask, updateStage tasks.UpdateStage, log tasks.LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
 	tag := task.Tag.Must().String()
 	index, err := strconv.Atoi(tag)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.1.5
 	github.com/filecoin-project/go-legs v0.3.7
 	github.com/filecoin-project/go-state-types v0.1.3
-	github.com/filecoin-project/lotus v1.13.3-0.20220208105256-b38adaa73640
+	github.com/filecoin-project/lotus v1.15.0-rc2
 	github.com/golang-migrate/migrate/v4 v4.14.2-0.20210511063805-2e7358e012a6
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
@@ -30,7 +30,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/kenlabs/pando v0.0.0-20220224155922-54cd14a34fca
 	github.com/lib/pq v1.10.3
-	github.com/libp2p/go-libp2p v0.18.0-rc4
+	github.com/libp2p/go-libp2p v0.18.0-rc5
 	github.com/libp2p/go-libp2p-core v0.14.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.5.0
@@ -43,6 +43,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/willscott/ipld-dumpjson v0.0.0-20210625231845-eb416d94fa54
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	helm.sh/helm/v3 v3.6.2
 	k8s.io/api v0.23.3
 	k8s.io/cli-runtime v0.23.3
@@ -129,7 +130,7 @@ require (
 	github.com/filecoin-project/specs-actors/v5 v5.0.4 // indirect
 	github.com/filecoin-project/specs-actors/v6 v6.0.1 // indirect
 	github.com/filecoin-project/specs-actors/v7 v7.0.0-rc1 // indirect
-	github.com/filecoin-project/specs-storage v0.1.1-0.20211228030229-6d460d25a0c9 // indirect
+	github.com/filecoin-project/specs-storage v0.2.0 // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
@@ -233,7 +234,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.6.1 // indirect
 	github.com/libp2p/go-libp2p-quic-transport v0.16.1 // indirect
 	github.com/libp2p/go-libp2p-resource-manager v0.1.3 // indirect
-	github.com/libp2p/go-libp2p-swarm v0.10.1 // indirect
+	github.com/libp2p/go-libp2p-swarm v0.10.2 // indirect
 	github.com/libp2p/go-libp2p-testing v0.7.0 // indirect
 	github.com/libp2p/go-libp2p-tls v0.3.2-0.20220104091339-280a5b5a7e79 // indirect
 	github.com/libp2p/go-libp2p-transport-upgrader v0.7.1 // indirect
@@ -246,7 +247,7 @@ require (
 	github.com/libp2p/go-reuseport v0.1.0 // indirect
 	github.com/libp2p/go-reuseport-transport v0.1.0 // indirect
 	github.com/libp2p/go-stream-muxer-multistream v0.4.0 // indirect
-	github.com/libp2p/go-tcp-transport v0.5.0 // indirect
+	github.com/libp2p/go-tcp-transport v0.5.1 // indirect
 	github.com/libp2p/go-ws-transport v0.6.0 // indirect
 	github.com/libp2p/go-yamux/v3 v3.0.2 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
@@ -353,7 +354,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.8 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4 // indirect
 	google.golang.org/grpc v1.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.m
 github.com/filecoin-project/go-padreader v0.0.0-20210723183308-812a16dc01b1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=
 github.com/filecoin-project/go-padreader v0.0.1 h1:8h2tVy5HpoNbr2gBRr+WD6zV6VD6XHig+ynSGJg8ZOs=
 github.com/filecoin-project/go-padreader v0.0.1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=
-github.com/filecoin-project/go-paramfetch v0.0.3-0.20220111000201-e42866db1a53 h1:+nripp+UI/rhl01w9Gs4V0XDGaVPYPMGU/D/gNVLue0=
-github.com/filecoin-project/go-paramfetch v0.0.3-0.20220111000201-e42866db1a53/go.mod h1:1FH85P8U+DUEmWk1Jkw3Bw7FrwTVUNHk/95PSPG+dts=
+github.com/filecoin-project/go-paramfetch v0.0.4 h1:H+Me8EL8T5+79z/KHYQQcT8NVOzYVqXIi7nhb48tdm8=
+github.com/filecoin-project/go-paramfetch v0.0.4/go.mod h1:1FH85P8U+DUEmWk1Jkw3Bw7FrwTVUNHk/95PSPG+dts=
 github.com/filecoin-project/go-state-types v0.0.0-20200903145444-247639ffa6ad/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
@@ -606,8 +606,8 @@ github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZO
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
 github.com/filecoin-project/go-storedcounter v0.1.0/go.mod h1:4ceukaXi4vFURIoxYMfKzaRF5Xv/Pinh2oTnoxpv+z8=
-github.com/filecoin-project/lotus v1.13.3-0.20220208105256-b38adaa73640 h1:iAPI3dbQqPIcTnPQDh2jClZYGEx38h864SjCkRTkSsM=
-github.com/filecoin-project/lotus v1.13.3-0.20220208105256-b38adaa73640/go.mod h1:aquq/IGckQ4x8demoIiq6n5nkmoltjFZPtdELhXP5X8=
+github.com/filecoin-project/lotus v1.15.0-rc2 h1:lQ4XvStHvMc+HN67xFJJfdvphWVietaI4vgW8/90hOM=
+github.com/filecoin-project/lotus v1.15.0-rc2/go.mod h1:c6tGjm0hmUvlmcYXpcfWAERJP/BR08qPtf32TuBMNWE=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors v0.9.14 h1:68PVstg2UB3ZsMLF+DKFTAs/YKsqhKWynkr0IqmVRQY=
 github.com/filecoin-project/specs-actors v0.9.14/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
@@ -629,8 +629,8 @@ github.com/filecoin-project/specs-actors/v6 v6.0.1/go.mod h1:V1AYfi5GkHXipx1mnVi
 github.com/filecoin-project/specs-actors/v7 v7.0.0-20211222192039-c83bea50c402/go.mod h1:p6LIOFezA1rgRLMewbvdi3Pp6SAu+q9FtJ9CAleSjrE=
 github.com/filecoin-project/specs-actors/v7 v7.0.0-rc1 h1:FuDaXIbcw2hRsFI8SDTmsGGCE+NumpF6aiBoU/2X5W4=
 github.com/filecoin-project/specs-actors/v7 v7.0.0-rc1/go.mod h1:TA5FwCna+Yi36POaT7SLKXsgEDvJwc0V/L6ZsO19B9M=
-github.com/filecoin-project/specs-storage v0.1.1-0.20211228030229-6d460d25a0c9 h1:oUYOvF7EvdXS0Zmk9mNkaB6Bu0l+WXBYPzVodKMiLug=
-github.com/filecoin-project/specs-storage v0.1.1-0.20211228030229-6d460d25a0c9/go.mod h1:Tb88Zq+IBJbvAn3mS89GYj3jdRThBTE/771HCVZdRJU=
+github.com/filecoin-project/specs-storage v0.2.0 h1:Y4UDv0apRQ3zI2GiPPubi8JblpUZZphEdaJUxCutfyg=
+github.com/filecoin-project/specs-storage v0.2.0/go.mod h1:Tb88Zq+IBJbvAn3mS89GYj3jdRThBTE/771HCVZdRJU=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
@@ -1580,8 +1580,8 @@ github.com/libp2p/go-libp2p v0.14.4/go.mod h1:EIRU0Of4J5S8rkockZM7eJp2S0UrCyi55m
 github.com/libp2p/go-libp2p v0.16.0/go.mod h1:ump42BsirwAWxKzsCiFnTtN1Yc+DuPu76fyMX364/O4=
 github.com/libp2p/go-libp2p v0.17.0/go.mod h1:Fkin50rsGdv5mm5BshBUtPRZknt9esfmYXBOYcwOTgw=
 github.com/libp2p/go-libp2p v0.18.0-rc1/go.mod h1:RgYlH7IIWHXREimC92bw5Lg1V2R5XmSzuLHb5fTnr+8=
-github.com/libp2p/go-libp2p v0.18.0-rc4 h1:OUsSbeu7q+Ck/bV9wHDxFzb08ORqBupHhpCmRBhWrJ8=
-github.com/libp2p/go-libp2p v0.18.0-rc4/go.mod h1:wzmsk1ioOq9FGQys2BN5BIw4nugP6+R+CyW3JbPEbbs=
+github.com/libp2p/go-libp2p v0.18.0-rc5 h1:88wWDHb9nNo0vBNCupLde3OTnFAkugOCNkrDfl3ivK4=
+github.com/libp2p/go-libp2p v0.18.0-rc5/go.mod h1:aZPS5l84bDvCvP4jkyEUT/J6YOpUq33Fgqrs3K59mpI=
 github.com/libp2p/go-libp2p-asn-util v0.0.0-20200825225859-85005c6cf052/go.mod h1:nRMRTab+kZuk0LnKZpxhOVH/ndsdr2Nr//Zltc/vwgo=
 github.com/libp2p/go-libp2p-asn-util v0.1.0 h1:rABPCO77SjdbJ/eJ/ynIo8vWICy1VEnL5JAxJbQLo1E=
 github.com/libp2p/go-libp2p-asn-util v0.1.0/go.mod h1:wu+AnM9Ii2KgO5jMmS1rz9dvzTdj8BXqsPR9HR0XB7I=
@@ -1775,8 +1775,8 @@ github.com/libp2p/go-libp2p-swarm v0.5.3/go.mod h1:NBn7eNW2lu568L7Ns9wdFrOhgRlkR
 github.com/libp2p/go-libp2p-swarm v0.8.0/go.mod h1:sOMp6dPuqco0r0GHTzfVheVBh6UEL0L1lXUZ5ot2Fvc=
 github.com/libp2p/go-libp2p-swarm v0.9.0/go.mod h1:2f8d8uxTJmpeqHF/1ujjdXZp+98nNIbujVOMEZxCbZ8=
 github.com/libp2p/go-libp2p-swarm v0.10.0/go.mod h1:71ceMcV6Rg/0rIQ97rsZWMzto1l9LnNquef+efcRbmA=
-github.com/libp2p/go-libp2p-swarm v0.10.1 h1:lXW3pgGt+BVmkzcFX61erX7l6Lt+WAamNhwa2Kf3eJM=
-github.com/libp2p/go-libp2p-swarm v0.10.1/go.mod h1:Pdkq0QU5a+qu+oyqIV3bknMsnzk9lnNyKvB9acJ5aZs=
+github.com/libp2p/go-libp2p-swarm v0.10.2 h1:UaXf+CTq6Ns1N2V1EgqJ9Q3xaRsiN7ImVlDMpirMAWw=
+github.com/libp2p/go-libp2p-swarm v0.10.2/go.mod h1:Pdkq0QU5a+qu+oyqIV3bknMsnzk9lnNyKvB9acJ5aZs=
 github.com/libp2p/go-libp2p-testing v0.0.1/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.0.2/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.0.3/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
@@ -1897,8 +1897,9 @@ github.com/libp2p/go-tcp-transport v0.2.3/go.mod h1:9dvr03yqrPyYGIEN6Dy5UvdJZjyP
 github.com/libp2p/go-tcp-transport v0.2.4/go.mod h1:9dvr03yqrPyYGIEN6Dy5UvdJZjyPFvl1S/igQ5QD1SU=
 github.com/libp2p/go-tcp-transport v0.2.7/go.mod h1:lue9p1b3VmZj1MhhEGB/etmvF/nBQ0X9CW2DutBT3MM=
 github.com/libp2p/go-tcp-transport v0.4.0/go.mod h1:0y52Rwrn4076xdJYu/51/qJIdxz+EWDAOG2S45sV3VI=
-github.com/libp2p/go-tcp-transport v0.5.0 h1:3ZPW8HAuyRAuFzyabE0hSrCXKKSWzROnZZX7DtcIatY=
 github.com/libp2p/go-tcp-transport v0.5.0/go.mod h1:UPPL0DIjQqiWRwVAb+CEQlaAG0rp/mCqJfIhFcLHc4Y=
+github.com/libp2p/go-tcp-transport v0.5.1 h1:edOOs688VLZAozWC7Kj5/6HHXKNwi9M6wgRmmLa8M6Q=
+github.com/libp2p/go-tcp-transport v0.5.1/go.mod h1:UPPL0DIjQqiWRwVAb+CEQlaAG0rp/mCqJfIhFcLHc4Y=
 github.com/libp2p/go-testutil v0.0.1/go.mod h1:iAcJc/DKJQanJ5ws2V+u5ywdL2n12X1WbbEG+Jjy69I=
 github.com/libp2p/go-testutil v0.1.0/go.mod h1:81b2n5HypcVyrCg/MJx4Wgfp/VHojytjVe/gLzZ2Ehc=
 github.com/libp2p/go-ws-transport v0.0.5/go.mod h1:Qbl4BxPfXXhhd/o0wcrgoaItHqA9tnZjoFZnxykuaXU=

--- a/lotus/client.go
+++ b/lotus/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/urfave/cli/v2"
 )
 
@@ -18,7 +17,7 @@ const defaultMinWalletFil = 100000000000000
 
 type NodeCloser func()
 
-func SetupClientFromCLI(cctx *cli.Context) (tasks.NodeConfig, v0api.FullNode, NodeCloser, error) {
+func SetupClientFromCLI(cctx *cli.Context) (tasks.NodeConfig, api.FullNode, NodeCloser, error) {
 	// read dir and assert it exists
 	dataDir := cctx.String("data-dir")
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
@@ -87,7 +86,7 @@ func SetupClientFromCLI(cctx *cli.Context) (tasks.NodeConfig, v0api.FullNode, No
 	}, node, closer, nil
 }
 
-func SetupClient(ctx context.Context, cliCtx *cli.Context) (tasks.NodeConfig, v0api.FullNode, NodeCloser, error) {
+func SetupClient(ctx context.Context, cliCtx *cli.Context) (tasks.NodeConfig, api.FullNode, NodeCloser, error) {
 	// read dir and assert it exists
 	dataDir := cliCtx.String("data-dir")
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {

--- a/lotus/gateway.go
+++ b/lotus/gateway.go
@@ -27,7 +27,7 @@ func NewGatewayOpener(ctx *cli.Context) (*GatewayOpener, APICloser, error) {
 
 	apiInfo := cliutil.ParseApiInfo(tokenMaddr)
 
-	addr, err := apiInfo.DialArgs("v0")
+	addr, err := apiInfo.DialArgs("v1")
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse listen address: %w", err)
 	}

--- a/lotus/lotus.go
+++ b/lotus/lotus.go
@@ -112,7 +112,7 @@ func NewAPIOpener(ctx *cli.Context) (*APIOpener, APICloser, error) {
 
 	apiInfo := cliutil.ParseApiInfo(tokenMaddr)
 
-	addr, err := apiInfo.DialArgs("v0")
+	addr, err := apiInfo.DialArgs("v1")
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse listen address: %w", err)
 	}

--- a/lotus/lotus.go
+++ b/lotus/lotus.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/client"
-	"github.com/filecoin-project/lotus/api/v0api"
 	cliutil "github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/lotus/node/repo"
 	logging "github.com/ipfs/go-log/v2"
@@ -60,7 +60,7 @@ func NewAPIOpenerFromCLI(cctx *cli.Context) (*APIOpener, APICloser, error) {
 		return nil, nil, fmt.Errorf("cannot connect to lotus api: missing --api or --repo flags")
 	}
 
-	addr, err := apiInfo.DialArgs("v0")
+	addr, err := apiInfo.DialArgs("v1")
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse listen address: %w", err)
 	}
@@ -73,8 +73,8 @@ func NewAPIOpenerFromCLI(cctx *cli.Context) (*APIOpener, APICloser, error) {
 	return o, APICloser(func() {}), nil
 }
 
-func (o *APIOpener) Open(ctx context.Context) (v0api.FullNode, jsonrpc.ClientCloser, error) {
-	return client.NewFullNodeRPCV0(ctx, o.addr, o.headers)
+func (o *APIOpener) Open(ctx context.Context) (api.FullNode, jsonrpc.ClientCloser, error) {
+	return client.NewFullNodeRPCV1(ctx, o.addr, o.headers)
 }
 
 func setupLogging(cctx *cli.Context) error {

--- a/tasks/retrieval_deal_test.go
+++ b/tasks/retrieval_deal_test.go
@@ -10,8 +10,7 @@ import (
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/api/v0api"
-	"github.com/filecoin-project/lotus/api/v0api/v0mocks"
+	"github.com/filecoin-project/lotus/api/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -27,12 +26,12 @@ func TestCancelOldDeals(t *testing.T) {
 	cancelID2 := retrievalmarket.DealID(rand.Uint64())
 
 	testCases := map[string]struct {
-		setExpectations func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder)
+		setExpectations func(t *testing.T, expect *mocks.MockFullNodeMockRecorder)
 		expectedErr     error
 		expectedLogs    []string
 	}{
 		"returns deals but non cancelled": {
-			setExpectations: func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder) {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(
 					[]api.RetrievalInfo{
 						{
@@ -50,7 +49,7 @@ func TestCancelOldDeals(t *testing.T) {
 			},
 		},
 		"returns error when fetching retrievals": {
-			setExpectations: func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder) {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(
 					[]api.RetrievalInfo{}, errors.New("something went wrong"),
 				)
@@ -58,7 +57,7 @@ func TestCancelOldDeals(t *testing.T) {
 			expectedErr: errors.New("something went wrong"),
 		},
 		"cancels a retrieval": {
-			setExpectations: func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder) {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(
 					[]api.RetrievalInfo{
 						{
@@ -80,7 +79,7 @@ func TestCancelOldDeals(t *testing.T) {
 			},
 		},
 		"no cancels cause of finality state": {
-			setExpectations: func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder) {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(
 					[]api.RetrievalInfo{
 						{
@@ -100,7 +99,7 @@ func TestCancelOldDeals(t *testing.T) {
 			expectedLogs: []string{},
 		},
 		"retrieval cancel errors": {
-			setExpectations: func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder) {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(
 					[]api.RetrievalInfo{
 						{
@@ -120,7 +119,7 @@ func TestCancelOldDeals(t *testing.T) {
 			expectedErr: errors.New("something went wrong"),
 		},
 		"cancels multiple retrievals": {
-			setExpectations: func(t *testing.T, expect *v0mocks.MockFullNodeMockRecorder) {
+			setExpectations: func(t *testing.T, expect *mocks.MockFullNodeMockRecorder) {
 				expect.ClientListRetrievals(gomock.Any()).Return(
 					[]api.RetrievalInfo{
 						{
@@ -152,7 +151,7 @@ func TestCancelOldDeals(t *testing.T) {
 			dealStage := CommonStages["ProposeDeal"]()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			node := v0mocks.NewMockFullNode(ctrl)
+			node := mocks.NewMockFullNode(ctrl)
 			de := &retrievalDealExecutor{
 				dealExecutor: dealExecutor{
 					ctx: ctx,
@@ -163,7 +162,7 @@ func TestCancelOldDeals(t *testing.T) {
 					log:  func(msg string, keysAndValues ...interface{}) {},
 				},
 				task: &_RetrievalTask{PayloadCID: _String{root.String()}},
-				offer: v0api.RetrievalOrder{
+				offer: api.RetrievalOrder{
 					Root: root,
 				},
 			}

--- a/tasks/storage_deal.go
+++ b/tasks/storage_deal.go
@@ -17,7 +17,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/google/uuid"
@@ -42,7 +41,7 @@ const (
 	startOffsetDefault = 30760
 )
 
-func MakeStorageDeal(ctx context.Context, config NodeConfig, node v0api.FullNode, task StorageTask, updateStage UpdateStage, log LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
+func MakeStorageDeal(ctx context.Context, config NodeConfig, node api.FullNode, task StorageTask, updateStage UpdateStage, log LogStatus, stageTimeouts map[string]time.Duration, releaseWorker func()) error {
 	de := &storageDealExecutor{
 		dealExecutor: dealExecutor{
 			ctx:           ctx,
@@ -116,7 +115,7 @@ func MakeStorageDeal(ctx context.Context, config NodeConfig, node v0api.FullNode
 type dealExecutor struct {
 	ctx           context.Context
 	config        NodeConfig
-	node          v0api.FullNode
+	node          api.FullNode
 	miner         string
 	log           LogStatus
 	tipSet        *types.TipSet

--- a/tasks/storage_deal_test.go
+++ b/tasks/storage_deal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/api/v0api/v0mocks"
+	"github.com/filecoin-project/lotus/api/mocks"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -27,7 +27,7 @@ func TestNetDiag(t *testing.T) {
 	mn := mocknet.New()
 	other, err := mn.GenPeer()
 	require.NoError(t, err)
-	node := v0mocks.NewMockFullNode(ctrl)
+	node := mocks.NewMockFullNode(ctrl)
 	node.EXPECT().NetAgentVersion(gomock.Eq(ctx), gomock.Eq(other.ID())).Return("1.12.0", nil)
 	node.EXPECT().Version(gomock.Eq(ctx)).Return(api.APIVersion{
 		Version: "1.11.0",
@@ -71,7 +71,7 @@ func TestExecuteDeal(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	node := v0mocks.NewMockFullNode(ctrl)
+	node := mocks.NewMockFullNode(ctrl)
 	root := generateRandomCID(t)
 	proposalCid := generateRandomCID(t)
 	basePrice := abi.NewTokenAmount(1000000000000)


### PR DESCRIPTION
# Goals

Get off deprecated APIs

# Implementations

Basically, this just takes lotus's retrieval CLI command's code and mashes it up with our existing retrieval code to hopefully produce the same set of updates back to the controller. We don't really have tests for retrieval, so I guess we'll see what it produces.

Hopefully the integration tests run in CI will give us a decent indicator of whether this has successfully done the thing?