### PR TITLE
Fix incorrect reference to CID whe fetching head metadata

### DIFF
--- a/cmd/client/dealbot.go
+++ b/cmd/client/dealbot.go
@@ -183,7 +183,7 @@ point to dealbot's records chain.`,
 								}
 
 								selHead := ssb.ExploreRecursive(selector.RecursionLimitDepth(0), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-								err = syncer.Sync(cctx.Context, rootCid, selHead)
+								err = syncer.Sync(cctx.Context, headMetaCid, selHead)
 								if err != nil {
 									return err
 								}


### PR DESCRIPTION
Fix typo in var name when fetching head metadata.